### PR TITLE
Avoid some array allocations

### DIFF
--- a/src/markd/html_entities.cr
+++ b/src/markd/html_entities.cr
@@ -63,8 +63,8 @@ module Markd::HTMLEntities
 
     def self.encode(source : String)
       source.gsub(ENTITIES_REGEX) { |chars| encode_entities(chars) }
-            .gsub(ASTRAL_REGEX) { |chars| encode_astral(chars) }
-            .gsub(ENCODE_REGEX) { |chars| encode_extend(chars) }
+        .gsub(ASTRAL_REGEX) { |chars| encode_astral(chars) }
+        .gsub(ENCODE_REGEX) { |chars| encode_extend(chars) }
     end
 
     private def self.encode_entities(chars : String)

--- a/src/markd/node.cr
+++ b/src/markd/node.cr
@@ -50,7 +50,7 @@ module Markd
     property type : Type
 
     property data = {} of String => DataValue
-    property source_pos = [[1, 1], [0, 0]]
+    property source_pos = [{1, 1}, {0, 0}]
     property text = ""
     property? open = true
     property? fenced = false

--- a/src/markd/node.cr
+++ b/src/markd/node.cr
@@ -50,7 +50,7 @@ module Markd
     property type : Type
 
     property data = {} of String => DataValue
-    property source_pos = [{1, 1}, {0, 0}]
+    property source_pos = { {1, 1}, {0, 0} }
     property text = ""
     property? open = true
     property? fenced = false

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -210,7 +210,10 @@ module Markd::Parser
       container_parent = container.parent?
 
       container.open = false
-      container.source_pos[1] = {line_number, @last_line_length}
+      container.source_pos = {
+        {container.source_pos[0][0], container.source_pos[0][1]},
+        {line_number, @last_line_length}
+      }
       RULES[container.type].token(self, container)
 
       @tip = container_parent

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -69,7 +69,7 @@ module Markd::Parser
     end
 
     private def prepare_input(source)
-      @lines = source.each_line.to_a
+      @lines = source.lines
       @line_size = @lines.size
       # ignore last blank line created by final newline
       @line_size -= 1 if source[-1]? == '\n'
@@ -210,7 +210,7 @@ module Markd::Parser
       container_parent = container.parent?
 
       container.open = false
-      container.source_pos[1] = [line_number, @last_line_length]
+      container.source_pos[1] = {line_number, @last_line_length}
       RULES[container.type].token(self, container)
 
       @tip = container_parent
@@ -239,7 +239,7 @@ module Markd::Parser
       column_number = offset + 1 # offset 0 = column 1
 
       node = Node.new(type)
-      node.source_pos = [[@current_line, column_number], [0, 0]]
+      node.source_pos = { {@current_line, column_number}, {0, 0} }
       node.text = ""
       tip.append_child(node)
       @tip = node

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -211,7 +211,7 @@ module Markd::Parser
 
       container.open = false
       container.source_pos = {
-        {container.source_pos[0][0], container.source_pos[0][1]},
+        container.source_pos[0],
         {line_number, @last_line_length}
       }
       RULES[container.type].token(self, container)

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -441,24 +441,24 @@ module Markd::Parser
       if text = match(Rule::MAIN)
         if @options.smart
           text = text.gsub(Rule::ELLIPSIS, '\u{2026}')
-                     .gsub(Rule::DASH) do |chars|
-            en_count = em_count = 0
-            chars_length = chars.size
+            .gsub(Rule::DASH) do |chars|
+              en_count = em_count = 0
+              chars_length = chars.size
 
-            if chars_length % 3 == 0
-              em_count = chars_length / 3
-            elsif chars_length % 2 == 0
-              en_count = chars_length / 2
-            elsif chars_length % 3 == 2
-              en_count = 1
-              em_count = (chars_length - 2) / 3
-            else
-              en_count = 2
-              em_count = (chars_length - 4) / 3
+              if chars_length % 3 == 0
+                em_count = chars_length / 3
+              elsif chars_length % 2 == 0
+                en_count = chars_length / 2
+              elsif chars_length % 3 == 2
+                en_count = 1
+                em_count = (chars_length - 2) / 3
+              else
+                en_count = 2
+                em_count = (chars_length - 4) / 3
+              end
+
+              "\u{2014}" * em_count + "\u{2013}" * en_count
             end
-
-            "\u{2014}" * em_count + "\u{2013}" * en_count
-          end
         end
         node.append_child(text(text))
         true

--- a/src/markd/rules/heading.cr
+++ b/src/markd/rules/heading.cr
@@ -15,8 +15,8 @@ module Markd::Rule
         container = parser.add_child(Node::Type::Heading, parser.next_nonspace)
         container.data["level"] = match[0].strip.size
         container.text = parser.line[parser.offset..-1]
-                 .sub(/^ *#+ *$/, "")
-                 .sub(/ +#+ *$/, "")
+          .sub(/^ *#+ *$/, "")
+          .sub(/ +#+ *$/, "")
 
         parser.advance_offset(parser.line.size - parser.offset)
 

--- a/src/markd/utils.cr
+++ b/src/markd/utils.cr
@@ -12,6 +12,7 @@ module Markd
     end
 
     DECODE_ENTITIES_REGEX = Regex.new("\\\\" + Rule::ESCAPABLE_STRING, Regex::Options::IGNORE_CASE)
+
     def self.decode_entities_string(text : String) : String
       HTML.decode_entities(text).gsub(DECODE_ENTITIES_REGEX) { |text| text[1].to_s }
     end


### PR DESCRIPTION
This replaces some arrays by tuples which avoids memory allocations, and this also runs the formatter.