### PR TITLE
Use URI#encode Replace URI#escape

### DIFF
--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -183,7 +183,7 @@ module Markd
     private def toc(node : Node)
       return unless node.type.heading?
 
-      title = URI.escape(node.text)
+      title = URI.encode(node.text)
 
       @output_io << %(<a id="anchor-) << title << %(" class="anchor" href="#) << title %("></a>)
       @last_output = ">"


### PR DESCRIPTION
The URI.escape method has been deprecated. I can't compile it on Crystal 0.31.0.

https://crystal-lang.org/api/0.30.1/URI.html#escape(string:String,io:IO,space_to_plus=false)-class-method