### PR TITLE
Optimizations

### DIFF
--- a/src/markd/node.cr
+++ b/src/markd/node.cr
@@ -49,7 +49,7 @@ module Markd
 
     property type : Type
 
-    property data = {} of String => DataValue
+    property(data) { {} of String => DataValue }
     property source_pos = { {1, 1}, {0, 0} }
     property text = ""
     property? open = true
@@ -126,7 +126,10 @@ module Markd
       io << " @type=" << @type
       io << " @parent=" << @parent if @parent
       io << " @next=" << @next if @next
-      io << " @data=" << @data if @data.size > 0
+
+      data = @data
+      io << " @data=" << data if data && !data.empty?
+
       io << ">"
       nil
     end

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -72,7 +72,7 @@ module Markd::Parser
       @lines = source.lines
       @line_size = @lines.size
       # ignore last blank line created by final newline
-      @line_size -= 1 if source[-1]? == '\n'
+      @line_size -= 1 if source.ends_with?('\n')
     end
 
     private def parse_blocks

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -63,17 +63,17 @@ module Markd::Parser
     end
 
     private def parse_blocks(source)
-      line_size = 0
+      lines_size = 0
       source.each_line do |line|
         process_line(line)
-        line_size += 1
+        lines_size += 1
       end
 
       # ignore last blank line created by final newline
-      line_size -= 1 if source.ends_with?('\n')
+      lines_size -= 1 if source.ends_with?('\n')
 
       while tip = tip?
-        token(tip, line_size)
+        token(tip, lines_size)
       end
     end
 

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -132,7 +132,7 @@ module Markd::Parser
           end
         end
 
-        matched = RULES.values.each do |rule|
+        matched = RULES.each_value do |rule|
           case rule.match(self, container)
           when Rule::MatchValue::Container
             container = tip

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -32,11 +32,9 @@ module Markd::Parser
       @oldtip = @tip
       @last_matched_container = @tip
 
-      @lines = [] of String
       @line = ""
 
       @current_line = 0
-      @line_size = 0
       @offset = 0
       @column = 0
       @last_line_length = 0
@@ -53,12 +51,8 @@ module Markd::Parser
     end
 
     def parse(source : String)
-      Utils.timer("preparing input", @options.time) do
-        prepare_input(source)
-      end
-
       Utils.timer("block parsing", @options.time) do
-        parse_blocks
+        parse_blocks(source)
       end
 
       Utils.timer("inline parsing", @options.time) do
@@ -68,18 +62,18 @@ module Markd::Parser
       @document
     end
 
-    private def prepare_input(source)
-      @lines = source.lines
-      @line_size = @lines.size
-      # ignore last blank line created by final newline
-      @line_size -= 1 if source.ends_with?('\n')
-    end
+    private def parse_blocks(source)
+      line_size = 0
+      source.each_line do |line|
+        process_line(line)
+        line_size += 1
+      end
 
-    private def parse_blocks
-      @lines.each { |line| process_line(line) }
+      # ignore last blank line created by final newline
+      line_size -= 1 if source.ends_with?('\n')
 
       while tip = tip?
-        token(tip, @line_size)
+        token(tip, line_size)
       end
     end
 

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -747,10 +747,12 @@ module Markd::Parser
       text[1..-2].strip.downcase.gsub("\n", " ")
     end
 
+    private RESERVED_CHARS = ['&', '+', ',', '(', ')', '#', '*', '!', '#', '$', '/', ':', ';', '?', '@', '=']
+
     def normalize_uri(uri : String)
       String.build do |io|
         URI.encode(decode_uri(uri), io) do |byte|
-          URI.unreserved?(byte) || ['&', '+', ',', '(', ')', '#', '*', '!', '#', '$', '/', ':', ';', '?', '@', '='].includes?(byte.chr)
+          URI.unreserved?(byte) || RESERVED_CHARS.includes?(byte.chr)
         end
       end
     end

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -71,7 +71,7 @@ module Markd::Parser
       last_child = node.last_child?
       # check previous node for trailing spaces
       if last_child && last_child.type.text? &&
-         last_child.text[-1]? == ' '
+         last_child.text.ends_with?(' ')
         hard_break = if last_child.text.size == 1
                        false # Must be space
                      else

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -796,7 +796,7 @@ module Markd::Parser
     private RESERVED_CHARS = ['&', '+', ',', '(', ')', '#', '*', '!', '#', '$', '/', ':', ';', '?', '@', '=']
 
     def normalize_uri(uri : String)
-      String.build do |io|
+      String.build(capacity: uri.bytesize) do |io|
         URI.encode(decode_uri(uri), io) do |byte|
           URI.unreserved?(byte) || RESERVED_CHARS.includes?(byte.chr)
         end

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -804,7 +804,11 @@ module Markd::Parser
     end
 
     def decode_uri(text : String)
-      URI.decode(text).gsub(/^&(\w+);$/) { |chars| HTML.decode_entities(chars) }
+      decoded = URI.decode(text)
+      if decoded.includes?('&') && decoded.includes?(';')
+        decoded = decoded.gsub(/^&(\w+);$/) { |chars| HTML.decode_entities(chars) }
+      end
+      decoded
     end
 
     class Bracket

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -731,7 +731,7 @@ module Markd::Parser
     private def match(regex : Regex) : String?
       text = @text.byte_slice(@pos)
       if match = text.match(regex)
-        @pos += match.byte_begin.not_nil! + match[0].bytesize
+        @pos += match.byte_end.not_nil!
         return match[0]
       end
     end

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -581,7 +581,7 @@ module Markd::Parser
     private def scan_delims(char : Char)
       num_delims = 0
       start_pos = @pos
-      if ['\'', '"'].includes?(char)
+      if char == '\'' || char == '"'
         num_delims += 1
         @pos += 1
       else

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -730,7 +730,7 @@ module Markd::Parser
     private def match(regex : Regex) : String?
       text = @text[@pos..-1]
       if match = text.match(regex)
-        @pos += text.index(regex).as(Int32) + match[0].size
+        @pos += match.begin.not_nil! + match[0].size
         return match[0]
       end
     end

--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -26,7 +26,24 @@ module Markd
     }
 
     def escape(text)
-      text.gsub(ESCAPES)
+      # If we can determine that the text has no escape chars
+      # then we can return the text as is, avoiding an allocation
+      # and a lot of processing in `String#gsub`.
+      if has_escape_char?(text)
+        text.gsub(ESCAPES)
+      else
+        text
+      end
+    end
+
+    private def has_escape_char?(text)
+      text.each_char do |char|
+        case char
+        when '&', '"', '<', '>'
+          return true
+        end
+      end
+      false
     end
 
     def render(document : Node)

--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -37,8 +37,8 @@ module Markd
     end
 
     private def has_escape_char?(text)
-      text.each_char do |char|
-        case char
+      text.each_byte do |byte|
+        case byte
         when '&', '"', '<', '>'
           return true
         end

--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -1,7 +1,7 @@
 module Markd
   abstract class Renderer
     def initialize(@options = Options.new)
-      @output_io = IO::Memory.new
+      @output_io = String::Builder.new
       @last_output = "\n"
     end
 

--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -18,13 +18,15 @@ module Markd
       lit("\n") if @last_output != "\n"
     end
 
+    private ESCAPES = {
+      '&' => "&amp;",
+      '"' => "&quot;",
+      '<' => "&lt;",
+      '>' => "&gt;",
+    }
+
     def escape(text)
-      text.gsub({
-        '&' => "&amp;",
-        '"' => "&quot;",
-        '<' => "&lt;",
-        '>' => "&gt;",
-      })
+      text.gsub(ESCAPES)
     end
 
     def render(document : Node)

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -33,7 +33,7 @@ module Markd
     end
 
     def code_block(node : Node, entering : Bool)
-      languages = node.fence_language ? node.fence_language.split(/\s+/) : nil
+      languages = node.fence_language ? node.fence_language.split : nil
       code_tag_attrs = attrs(node)
       pre_tag_attrs = if @options.prettyprint
                         {"class" => "prettyprint"}

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -33,6 +33,7 @@ module Markd
                       end
 
       if languages.size > 0 && (lang = languages[0]) && !lang.empty?
+        code_tag_attrs ||= {} of String => String
         code_tag_attrs["class"] = "language-#{lang.strip}"
       end
 
@@ -61,6 +62,7 @@ module Markd
       attrs = attrs(node)
       tag_name = node.data["type"] == "bullet" ? "ul" : "ol"
       if entering && (start = node.data["start"].as(Int32)) && start != 1
+        attrs ||= {} of String => String
         attrs["start"] = start.to_s
       end
 
@@ -82,10 +84,12 @@ module Markd
       if entering
         attrs = attrs(node)
         if !(@options.safe && potentially_unsafe(node.data["destination"].as(String)))
+          attrs ||= {} of String => String
           attrs["href"] = escape(node.data["destination"].as(String))
         end
 
         if (title = node.data["title"].as(String)) && !title.empty?
+          attrs ||= {} of String => String
           attrs["title"] = escape(title)
         end
 
@@ -163,11 +167,11 @@ module Markd
       out(node.text)
     end
 
-    private def tag(name : String, attrs = {} of String => String, self_closing = false)
+    private def tag(name : String, attrs = nil, self_closing = false)
       return if @disable_tag > 0
 
       @output_io << "<" << name
-      attrs.each do |key, value|
+      attrs.try &.each do |key, value|
         @output_io << ' ' << key << '=' << '"' << value << '"'
       end
 
@@ -190,13 +194,11 @@ module Markd
     end
 
     private def attrs(node : Node)
-      attr = {} of String => String
-
       if @options.source_pos && (pos = node.source_pos)
-        attr["data-source-pos"] = "#{pos[0][0]}:#{pos[0][1]}-#{pos[1][0]}:#{pos[1][1]}"
+        {"data-source-pos" => "#{pos[0][0]}:#{pos[0][1]}-#{pos[1][0]}:#{pos[1][1]}"}
+      else
+        nil
       end
-
-      attr
     end
   end
 end

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -69,14 +69,22 @@ module Markd
 
     def list(node : Node, entering : Bool)
       attrs = attrs(node)
-      tag_name = node.data["type"] == "bullet" ? "ul" : "ol"
+
+      if node.data["type"] == "bullet"
+        tag_name = "ul"
+        end_tag_name = "/ul"
+      else
+        tag_name = "ol"
+        end_tag_name = "/ol"
+      end
+
       if entering && (start = node.data["start"].as(Int32)) && start != 1
         attrs ||= {} of String => String
         attrs["start"] = start.to_s
       end
 
       cr
-      entering ? tag(tag_name, attrs) : tag("/#{tag_name}")
+      entering ? tag(tag_name, attrs) : tag(end_tag_name)
       cr
     end
 

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -38,7 +38,7 @@ module Markd
       pre_tag_attrs = if @options.prettyprint
                         {"class" => "prettyprint"}
                       else
-                        {} of String => String
+                        nil
                       end
 
       if languages.size > 0 && (lang = languages[0]) && !lang.empty?

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -5,14 +5,23 @@ module Markd
     @disable_tag = 0
     @last_output = "\n"
 
+    private HEADINGS = {
+      1 => {"h1", "/h1"},
+      2 => {"h2", "/h2"},
+      3 => {"h3", "/h3"},
+      4 => {"h4", "/h4"},
+      5 => {"h5", "/h5"},
+      6 => {"h6", "/h6"},
+    }
+
     def heading(node : Node, entering : Bool)
-      tag_name = "h#{node.data["level"]}"
+      tag_name, end_tag_name = HEADINGS[node.data["level"]]
       if entering
         cr
         tag(tag_name, attrs(node))
         # toc(node) if @options.toc
       else
-        tag("/#{tag_name}")
+        tag(end_tag_name)
         cr
       end
     end

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -33,7 +33,7 @@ module Markd
     end
 
     def code_block(node : Node, entering : Bool)
-      languages = node.fence_language ? node.fence_language.split(/\s+/) : [] of String
+      languages = node.fence_language ? node.fence_language.split(/\s+/) : nil
       code_tag_attrs = attrs(node)
       pre_tag_attrs = if @options.prettyprint
                         {"class" => "prettyprint"}
@@ -41,7 +41,7 @@ module Markd
                         nil
                       end
 
-      if languages.size > 0 && (lang = languages[0]) && !lang.empty?
+      if languages && languages.size > 0 && (lang = languages[0]) && !lang.empty?
         code_tag_attrs ||= {} of String => String
         code_tag_attrs["class"] = "language-#{lang.strip}"
       end

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -5,17 +5,10 @@ module Markd
     @disable_tag = 0
     @last_output = "\n"
 
-    private HEADINGS = {
-      1 => "h1",
-      2 => "h2",
-      3 => "h3",
-      4 => "h4",
-      5 => "h5",
-      6 => "h6",
-    }
+    private HEADINGS = %w(h1 h2 h3 h4 h5 h6)
 
     def heading(node : Node, entering : Bool)
-      tag_name = HEADINGS[node.data["level"]]
+      tag_name = HEADINGS[node.data["level"].as(Int32) - 1]
       if entering
         cr
         tag(tag_name, attrs(node))

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -17,8 +17,6 @@ module Markd
 
     ESCAPABLE = /^#{ESCAPABLE_STRING}/
 
-    MAIN = /^[^\n`\[\]\\!<&*_'"]+/m
-
     TICKS = /`+/
 
     ELLIPSIS = "..."

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -102,7 +102,7 @@ module Markd
     abstract def accepts_lines? : Bool
 
     private def space_or_tab?(char : Char?) : Bool
-      [' ', '\t'].includes?(char)
+      char == ' ' || char == '\t'
     end
   end
 end

--- a/src/markd/rules/html_block.cr
+++ b/src/markd/rules/html_block.cr
@@ -25,7 +25,7 @@ module Markd::Rule
     end
 
     def continue(parser : Parser, container : Node)
-      (parser.blank && [5, 6].includes?(container.data["html_block_type"])) ? ContinueStatus::Stop : ContinueStatus::Continue
+      (parser.blank && {5, 6}.includes?(container.data["html_block_type"])) ? ContinueStatus::Stop : ContinueStatus::Continue
     end
 
     def token(parser : Parser, container : Node)

--- a/src/markd/rules/list.cr
+++ b/src/markd/rules/list.cr
@@ -139,7 +139,7 @@ module Markd::Rule
       while container
         return true if container.last_line_blank?
 
-        break unless [Node::Type::List, Node::Type::Item].includes?(container.type)
+        break unless container.type == Node::Type::List || container.type == Node::Type::Item
         container = container.last_child?
       end
 

--- a/src/markd/rules/paragraph.cr
+++ b/src/markd/rules/paragraph.cr
@@ -15,7 +15,7 @@ module Markd::Rule
 
       while container.text[0]? == '[' &&
             (pos = parser.inline_lexer.reference(container.text, parser.refmap)) && pos > 0
-        container.text = container.text[pos..-1]
+        container.text = container.text.byte_slice(pos)
         has_reference_defs = true
       end
 


### PR DESCRIPTION
This PR optimizes Markd code. Each commit has one optimization. The most controversial one is about not indexing strings with indices like `string[index]` but instead using `string.byte_at(index)`. Because Markdown is an ASCII format (well, there's unicode but the control characters like `*`, `_`, `[`, etc. are all ASCII) we can go byte per byte. But all optimizations here are good.

I used two benchmarks:

```crystal
require "./src/markd"
require "benchmark"
require "markdown"

text = "hello world"
# text = File.read("README.md")

Benchmark.ips do |x|
  x.report("std") { Markdown.to_html(text) }
  x.report("markd") { Markd.to_html(text) }
end
```

The first one is the code above. The second one is using the uncommented line, where "README.md" is this repo's README.md (I actually wanted to use the "sample markdown file" mentioned in the README but it seems it doesn't exist anymore).

In the code above `require "markdown"` is just the std's (incomplete, buggy) markdown.

# Results

## Hello world

### Before this PR

```
  std   3.49M (286.71ns) (± 2.95%)    384B/op        fastest
markd 342.15k (  2.92µs) (± 4.93%)  4.09kB/op  10.19× slower
```

### After this PR

```
  std   3.59M (278.37ns) (± 0.81%)    384B/op        fastest
markd 962.57k (  1.04µs) (± 1.79%)  1.46kB/op   3.73× slower
```

## README.md

### Before this PR

```
  std  25.44k ( 39.31µs) (± 1.39%)  46.1kB/op        fastest
markd   2.22k (449.56µs) (± 1.48%)   408kB/op  11.44× slower
```

### After this PR

```
  std  25.92k ( 38.58µs) (± 0.56%)  46.1kB/op        fastest
markd   5.22k (191.64µs) (± 1.64%)   175kB/op   4.97× slower
```

# Conclusion

It seems time and memory went down by 3 times.

I tried to optimize more but it's harder and harder without me trying to understand more the code. But I think this is good enough: 3~4 times slower than std but without bugs and feature complete is really good! And I'm tempted to ask you to maybe move markd to the standard library so we have a really good doc generate and a good Markdown library in the standard library, but we'll have to discuss that in the Crystal repo.