### PR TITLE
Refactor HTMLRenderer code block languages

### DIFF
--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -34,9 +34,9 @@ module Markd
                         nil
                       end
 
-      if languages && languages.size > 0 && (lang = languages[0]) && !lang.empty?
+      if lang = code_block_language(languages)
         code_tag_attrs ||= {} of String => String
-        code_tag_attrs["class"] = "language-#{escape(lang.strip)}"
+        code_tag_attrs["class"] = "language-#{escape(lang)}"
       end
 
       newline
@@ -46,6 +46,10 @@ module Markd
         end
       end
       newline
+    end
+
+    def code_block_language(languages)
+      languages.try(&.first?).try(&.strip.presence)
     end
 
     def thematic_break(node : Node, entering : Bool)

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -21,8 +21,12 @@ module Markd
 
     def code(node : Node, entering : Bool)
       tag("code") do
-        output(node.text)
+        code_body(node)
       end
+    end
+
+    def code_body(node : Node)
+      output(node.text)
     end
 
     def code_block(node : Node, entering : Bool)
@@ -42,7 +46,7 @@ module Markd
       newline
       tag("pre", pre_tag_attrs) do
         tag("code", code_tag_attrs) do
-          output(node.text)
+          code_block_body(node)
         end
       end
       newline
@@ -50,6 +54,10 @@ module Markd
 
     def code_block_language(languages)
       languages.try(&.first?).try(&.strip.presence)
+    end
+
+    def code_block_body(node : Node)
+      output(node.text)
     end
 
     def thematic_break(node : Node, entering : Bool)


### PR DESCRIPTION
This patch extracts a couple of methods in HTMLRenderer which allow to easier hook in to change certain aspects of a render method, without having to override the entire method and duplicate all steps.

Use cases are for Crystal's API docs rendering: https://github.com/crystal-lang/crystal/blob/32659bc7c6be76111afc3dc00ef4ac5fcee5806d/src/compiler/crystal/tools/doc/markd_doc_renderer.cr (see https://github.com/crystal-lang/crystal/pull/11040).