### PR TITLE
refactor(*): integrate ameba linting

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,0 +1,5 @@
+Lint/NotNil:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false

--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,11 @@ version: 0.5.0
 authors:
   - icyleaf <icyleaf.cn@gmail.com>
 
+development_dependencies:
+  ameba:
+    github: crystal-ameba/ameba
+    version: ~> 1.4.0
+
 crystal: ">= 0.36.1, < 2.0.0"
 
 license: MIT

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -52,9 +52,6 @@ def assert_example(file, section, index, example, smart)
 end
 
 def extract_spec_tests(file)
-  data = [] of String
-  delimiter = "`" * 32
-
   examples = {} of String => Hash(Int32, Hash(String, String))
 
   current_section = 0

--- a/src/markd/html_entities.cr
+++ b/src/markd/html_entities.cr
@@ -27,13 +27,8 @@ module Markd::HTMLEntities
     def self.decode_entity(chars)
       if chars[0] == '#'
         if chars.size > 1
-          if chars[1].downcase == 'x'
-            if chars.size > 2
-              return decode_codepoint(chars[2..-1].to_i(16))
-            end
-          else
-            return decode_codepoint(chars[1..-1].to_i(10))
-          end
+          return decode_codepoint(chars[1..-1].to_i(10)) unless chars[1].downcase == 'x'
+          return decode_codepoint(chars[2..-1].to_i(16)) if chars.size > 2
         end
       else
         entities_key = chars[0..-1]

--- a/src/markd/node.cr
+++ b/src/markd/node.cr
@@ -156,7 +156,7 @@ module Markd
           end
         elsif current == @root
           @current = nil
-        elsif nxt = current.next?
+        elsif current.next?
           @current = current.next?
           @entering = true
         else

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -173,7 +173,7 @@ module Markd::Parser
           add_line
 
           # if HtmlBlock, check for end condition
-          if (container_type.html_block? && match_html_block?(container))
+          if container_type.html_block? && match_html_block?(container)
             token(container, @current_line)
           end
         elsif @offset < line.size && !@blank
@@ -192,7 +192,7 @@ module Markd::Parser
     private def process_inlines
       walker = @document.walker
       @inline_lexer.refmap = @refmap
-      while (event = walker.next)
+      while event = walker.next
         node, entering = event
         if !entering && (node.type.paragraph? || node.type.heading?)
           @inline_lexer.parse(node)

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -327,9 +327,7 @@ module Markd::Parser
 
           case closer_char
           when '*', '_'
-            unless opener
-              closer = closer.next?
-            else
+            if opener
               # calculate actual number of delimiters used from closer
               use_delims = (closer.num_delims >= 2 && opener.num_delims >= 2) ? 2 : 1
               opener_inl = opener.node
@@ -370,6 +368,8 @@ module Markd::Parser
                 remove_delimiter(closer)
                 closer = tmp_stack
               end
+            else
+              closer = closer.next?
             end
           when '\''
             closer.node.text = "\u{2019}"
@@ -587,10 +587,9 @@ module Markd::Parser
     end
 
     private def remove_delimiter_between(bottom : Delimiter, top : Delimiter)
-      if bottom.next? != top
-        bottom.next = top
-        top.previous = bottom
-      end
+      return unless bottom.next? != top
+      bottom.next = top
+      top.previous = bottom
     end
 
     private def scan_delims(char : Char)
@@ -713,7 +712,7 @@ module Markd::Parser
         }
       end
 
-      return @pos - startpos
+      @pos - startpos
     end
 
     private def space_at_end_of_line?
@@ -728,7 +727,8 @@ module Markd::Parser
       else
         return false
       end
-      return true
+
+      true
     end
 
     # Parse zero or more space characters, including at most one newline
@@ -744,15 +744,15 @@ module Markd::Parser
         @pos += 1
       end
 
-      return true
+      true
     end
 
     private def match(regex : Regex) : String?
       text = @text.byte_slice(@pos)
-      if match = text.match(regex)
-        @pos += match.byte_end.not_nil!
-        return match[0]
-      end
+      return unless match = text.match(regex)
+      @pos += match.byte_end.not_nil!
+
+      match[0]
     end
 
     private def match_main : String?

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -222,7 +222,7 @@ module Markd
       @last_output = ">"
     end
 
-    private def tag(name : String, attrs = nil)
+    private def tag(name : String, attrs = nil, &)
       tag(name, attrs)
       yield
       tag(name, end_tag: true)

--- a/src/markd/rules/block_quote.cr
+++ b/src/markd/rules/block_quote.cr
@@ -42,10 +42,7 @@ module Markd::Rule
     private def seek(parser : Parser)
       parser.advance_next_nonspace
       parser.advance_offset(1, false)
-
-      if space_or_tab?(parser.line[parser.offset]?)
-        parser.advance_offset(1, true)
-      end
+      parser.advance_offset(1, true) if space_or_tab?(parser.line[parser.offset]?)
     end
   end
 end

--- a/src/markd/rules/html_block.cr
+++ b/src/markd/rules/html_block.cr
@@ -8,8 +8,8 @@ module Markd::Rule
         block_type_size = Rule::HTML_BLOCK_OPEN.size - 1
 
         Rule::HTML_BLOCK_OPEN.each_with_index do |regex, index|
-          if (text.match(regex) &&
-             (index < block_type_size || !container.type.paragraph?))
+          if text.match(regex) &&
+             (index < block_type_size || !container.type.paragraph?)
             parser.close_unmatched_blocks
             # We don't adjust parser.offset;
             # spaces are part of the HTML block:

--- a/src/markd/rules/item.cr
+++ b/src/markd/rules/item.cr
@@ -11,12 +11,8 @@ module Markd::Rule
       indent_offset = container.data["marker_offset"].as(Int32) + container.data["padding"].as(Int32)
 
       if parser.blank
-        if container.first_child?
-          parser.advance_next_nonspace
-        else
-          # Blank line after empty list item
-          return ContinueStatus::Stop
-        end
+        return ContinueStatus::Stop unless container.first_child?
+        parser.advance_next_nonspace
       elsif parser.indent >= indent_offset
         parser.advance_offset(indent_offset, true)
       else

--- a/src/markd/rules/list.cr
+++ b/src/markd/rules/list.cr
@@ -6,7 +6,7 @@ module Markd::Rule
     ORDERED_LIST_MARKERS = {'.', ')'}
 
     def match(parser : Parser, container : Node) : MatchValue
-      if (!parser.indented || container.type.list?)
+      if !parser.indented || container.type.list?
         data = parse_list_marker(parser, container)
         return MatchValue::None unless data && !data.empty?
 

--- a/src/markd/utils.cr
+++ b/src/markd/utils.cr
@@ -2,7 +2,7 @@ require "json"
 
 module Markd
   module Utils
-    def self.timer(label : String, measure_time? : Bool)
+    def self.timer(label : String, measure_time? : Bool, &)
       return yield unless measure_time?
 
       start_time = Time.utc
@@ -14,7 +14,7 @@ module Markd
     DECODE_ENTITIES_REGEX = Regex.new("\\\\" + Rule::ESCAPABLE_STRING, Regex::Options::IGNORE_CASE)
 
     def self.decode_entities_string(text : String) : String
-      HTML.decode_entities(text).gsub(DECODE_ENTITIES_REGEX) { |text| text[1].to_s }
+      HTML.decode_entities(text).gsub(DECODE_ENTITIES_REGEX, &.[1].to_s)
     end
   end
 end


### PR DESCRIPTION
Integrates [Ameba](https://github.com/crystal-ameba/ameba) into the codebase with coverage for the majority of linting rules. Excluded ones either required too many changes or were potentially damaging.