### PR TITLE
Use correct version check for `Crystal::VERSION`

### DIFF
--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -235,7 +235,7 @@ module Markd
     private def toc(node : Node)
       return unless node.type.heading?
 
-      {% if Crystal::VERSION < "1.2.0" %}
+      {% if compare_versions(Crystal::VERSION, "1.2.0") < 0 %}
         title = URI.encode(node.first_child.text)
         @output_io << %(<a id="anchor-) << title << %(" class="anchor" href="#anchor-) << title << %("></a>)
       {% else %}


### PR DESCRIPTION
`compare_versions` should be used instead of a normal string comparison, so that 1.10.0 and above do not incorrectly use the deprecated method.