### PR TITLE
gfm task list / checkbox support

### DIFF
--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -5105,7 +5105,7 @@ implementors are free to render the checkboxes as disabled or inmutable elements
 or they may dynamically handle dynamic interactions (i.e. checking, unchecking) in
 the final rendered document.
 
-```````````````````````````````` example disabled pending
+```````````````````````````````` example disabled
 - [ ] foo
 - [x] bar
 .
@@ -5117,7 +5117,7 @@ the final rendered document.
 
 Task lists can be arbitrarily nested:
 
-```````````````````````````````` example disabled pending
+```````````````````````````````` example disabled
 - [x] foo
   - [ ] bar
   - [x] baz

--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -5949,12 +5949,12 @@ document <https://html.spec.whatwg.org/multipage/entities.json>
 is used as an authoritative source for the valid entity
 references and their corresponding code points.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 &nbsp; &amp; &copy; &AElig; &Dcaron;
 &frac34; &HilbertSpace; &DifferentialD;
 &ClockwiseContourIntegral; &ngE;
 .
-<p>  &amp; © Æ Ď
+<p>  &amp; © Æ Ď
 ¾ ℋ ⅆ
 ∲ ≧̸</p>
 ````````````````````````````````
@@ -6192,19 +6192,19 @@ sides of the string:
 Only [spaces], and not [unicode whitespace] in general, are
 stripped in this way:
 
-```````````````````````````````` example pending
-` b `
+```````````````````````````````` example
+` b `
 .
-<p><code> b </code></p>
+<p><code> b </code></p>
 ````````````````````````````````
 
 No stripping occurs if the code span contains only spaces:
 
 ```````````````````````````````` example
-` `
+` `
 `  `
 .
-<p><code> </code>
+<p><code> </code>
 <code>  </code></p>
 ````````````````````````````````
 
@@ -6597,10 +6597,10 @@ a*"foo"*
 
 Unicode nonbreaking spaces count as whitespace, too:
 
-```````````````````````````````` example pending
-* a *
+```````````````````````````````` example
+* a *
 .
-<p>* a *</p>
+<p>* a *</p>
 ````````````````````````````````
 
 
@@ -8023,8 +8023,8 @@ may be used in titles:
 Titles must be separated from the link using a [whitespace].
 Other [Unicode whitespace] like non-breaking space doesn't work.
 
-```````````````````````````````` example pending
-[link](/url "title")
+```````````````````````````````` example
+[link](/url "title")
 .
 <p><a href="/url%C2%A0%22title%22">link</a></p>
 ````````````````````````````````

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -24,6 +24,8 @@ module Markd::Parser
     getter line, current_line, blank, inline_lexer,
       indent, indented, next_nonspace, refmap
 
+    delegate gfm, to: @options
+
     def initialize(@options : Options)
       @inline_lexer = Inline.new(@options)
 
@@ -289,7 +291,7 @@ module Markd::Parser
       nil
     end
 
-    def advance_offset(count, columns = false)
+    def advance_offset(count : Int32, columns = false)
       line = @line
       while count > 0 && (char = line[@offset]?)
         if char == '\t'

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -78,7 +78,7 @@ module Markd
     end
 
     def list(node : Node, entering : Bool)
-      tag_name = node.data["type"] == "bullet" ? "ul" : "ol"
+      tag_name = node.data["type"] == "ordered" ? "ol" : "ul"
 
       newline
       if entering
@@ -99,6 +99,24 @@ module Markd
     def item(node : Node, entering : Bool)
       if entering
         tag("li", attrs(node))
+
+        if node.data["type"] == "checkbox"
+          if node.data["checked"]?
+            attributes = {
+              "checked"  => "",
+              "disabled" => "",
+              "type"     => "checkbox",
+            }
+          else
+            attributes = {
+              "disabled" => "",
+              "type"     => "checkbox",
+            }
+          end
+
+          tag("input", attributes)
+          literal(" ")
+        end
       else
         tag("li", end_tag: true)
         newline

--- a/src/markd/rules/list.cr
+++ b/src/markd/rules/list.cr
@@ -82,8 +82,21 @@ module Markd::Rule
       line = parser.line[parser.next_nonspace..-1]
 
       if BULLET_LIST_MARKERS.includes?(line[0])
-        data["type"] = "bullet"
-        data["bullet_char"] = line[0].to_s
+        if parser.gfm && line[1..].strip.starts_with?("[ ]")
+          data["type"] = "checkbox"
+          data["bullet_char"] = line[0].to_s
+          data["checked"] = false
+          padding_checkbox = line.index!(']')
+        elsif parser.gfm && line[1..].strip.starts_with?("[x]")
+          data["type"] = "checkbox"
+          data["bullet_char"] = line[0].to_s
+          data["checked"] = true
+          padding_checkbox = line.index!(']')
+        else
+          data["type"] = "bullet"
+          data["bullet_char"] = line[0].to_s
+        end
+
         first_match_size = 1
       else
         pos = 0
@@ -114,6 +127,12 @@ module Markd::Rule
 
       parser.advance_next_nonspace
       parser.advance_offset(first_match_size, true)
+
+      # Skip past the checkbox brackets ([])
+      if parser.gfm && padding_checkbox
+        parser.advance_offset(padding_checkbox, true)
+      end
+
       spaces_start_column = parser.column
       spaces_start_offset = parser.offset
 


### PR DESCRIPTION
This pull request adds support for GFM task lists / checkboxes, as well as fixing some issues with spacing in `gfm-spec.txt`, bringing the current number of pending tests down to 30.

```crystal
require "./src/markd"

markdown = <<-MD
# Hello Markd

> Yet another markdown parser built for speed, written in Crystal, Compliant to CommonMark specification.
> - [ ] check box

- [ ] one
  - [x] two
    - [ ] three
MD

options = Markd::Options.new(gfm: true)
puts Markd.to_html(markdown, options)
```

```html
<h1>Hello Markd</h1>
<blockquote>
<p>Yet another markdown parser built for speed, written in Crystal, Compliant to CommonMark specification.</p>
<ul>
<li><input disabled="" type="checkbox"> check box</li>
</ul>
</blockquote>
<ul>
<li><input disabled="" type="checkbox"> one
<ul>
<li><input checked="" disabled="" type="checkbox"> two
<ul>
<li><input disabled="" type="checkbox"> three</li>
</ul>
</li>
</ul>
</li>
</ul>
```