### PR TITLE
gfm: add tagfilter option

### DIFF
--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -9644,7 +9644,7 @@ usually undesireable in the context of other rendered Markdown content.
 
 All other HTML tags are left untouched.
 
-```````````````````````````````` example tagfilter pending
+```````````````````````````````` example tagfilter
 <strong> <title> <style> <em>
 
 <blockquote>

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -48,6 +48,7 @@ def assert_example(file, section, index, example, smart, gfm = false)
   options = Markd::Options.new(
     gfm: gfm || example["test_tag"] == "gfm",
     emoji: example["test_tag"] == "emoji",
+    tagfilter: example["test_tag"] == "tagfilter"
   )
   options.smart = true if smart
 

--- a/src/markd/options.cr
+++ b/src/markd/options.cr
@@ -44,6 +44,8 @@ module Markd
 
     property emoji : Bool
 
+    property tagfilter : Bool
+
     def initialize(
       @time = false,
       @gfm = false,
@@ -53,6 +55,7 @@ module Markd
       @safe = false,
       @prettyprint = false,
       @emoji = false,
+      @tagfilter = false,
       @base_url = nil
     )
     end

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -24,7 +24,7 @@ module Markd::Parser
     getter line, current_line, blank, inline_lexer,
       indent, indented, next_nonspace, refmap
 
-    delegate gfm, to: @options
+    delegate gfm, tagfilter, to: @options
 
     def initialize(@options : Options)
       @inline_lexer = Inline.new(@options)

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -434,6 +434,11 @@ module Markd::Parser
     private def html_tag(node : Node)
       if text = match(Rule::HTML_TAG)
         child = Node.new(Node::Type::HTMLInline)
+
+        if @options.gfm && @options.tagfilter
+          text = Rule::HTMLBlock.escape_disallowed_html(text)
+        end
+
         child.text = text
         node.append_child(child)
         true

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -75,6 +75,8 @@ module Markd
 
     CODE_INDENT = 4
 
+    GFM_DISALLOWED_HTML_TAGS = %w[title textarea style xmp iframe noembed noframes script plaintext]
+
     # Match Value
     #
     # - None: no match


### PR DESCRIPTION
When enabled (alongside the gfm option), it will escape certain HTML tags

```crystal
require "./src/markd"

markdown = <<-MD
# Hello Markd

> Yet another markdown parser built for speed, written in Crystal, Compliant to CommonMark specification.

<title>this isn't allowed</title>

<style>
  title {
    font-size: 100px;
  }
</style>
MD

options = Markd::Options.new(gfm: true, tagfilter: true)
puts Markd.to_html(markdown, options)
```

Output:
```html
<h1>Hello Markd</h1>
<blockquote>
<p>Yet another markdown parser built for speed, written in Crystal, Compliant to CommonMark specification.</p>
</blockquote>
&lt;title>this isn't allowed&lt;/title>
&lt;style>
  title {
    font-size: 100px;
  }
&lt;/style>
```