### PR TITLE
Add more specs, strikethrough / task list improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # vscode
 /.history/
+/.vscode/settings.json

--- a/spec/fixtures/emoji.txt
+++ b/spec/fixtures/emoji.txt
@@ -35,23 +35,3 @@
 .
 <p>👨‍👦‍👦</p>
 ````````````````````````````````
-10,212 changes: 10,212 additions & 0 deletions
-10,212
-spec/fixtures/gfm-spec.txt
-Large diffs are not rendered by default.
-
-8 changes: 8 additions & 0 deletions
-8
-spec/fixtures/regression.txt
-@@ -147,3 +147,11 @@ Issue #289.
-.
-<p>[a](&lt;b) c&gt;</p>
-````````````````````````````````
-
-Don't strikethrough with only one tilde.
-
-```````````````````````````````` example gfm
-~hello~
-.
-<p>~hello~</p>
-````````````````````````````````

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -839,8 +839,8 @@ Autolink and tables.
 - [x] bar
 .
 <ul>
-<li><input type="checkbox" disabled="" /> foo</li>
-<li><input type="checkbox" checked="" disabled="" /> bar</li>
+<li><input disabled="" type="checkbox"> foo</li>
+<li><input checked="" disabled="" type="checkbox"> bar</li>
 </ul>
 ````````````````````````````````
 
@@ -864,13 +864,13 @@ Show a regular (non task) list to show that it has the same structure
 - [@] bim
 .
 <ul>
-<li><input type="checkbox" checked="" disabled="" /> foo
+<li><input checked="" disabled="" type="checkbox"> foo
 <ul>
-<li><input type="checkbox" disabled="" /> bar</li>
-<li><input type="checkbox" checked="" disabled="" /> baz</li>
+<li><input disabled="" type="checkbox"> bar</li>
+<li><input checked="" disabled="" type="checkbox"> baz</li>
 </ul>
 </li>
-<li><input type="checkbox" disabled="" /> bim</li>
+<li><input disabled="" type="checkbox"> bim</li>
 </ul>
 <p>Show a regular (non task) list to show that it has the same structure</p>
 <ul>
@@ -899,13 +899,13 @@ Show a regular (non task) list to show that it has the same structure
 - [@] bim
 .
 <ul>
-<li><input type="checkbox" checked="" disabled="" /> foo
+<li><input checked="" disabled="" type="checkbox"> foo
 <ul>
-<li><input type="checkbox" disabled="" /> bar</li>
-<li><input type="checkbox" checked="" disabled="" /> baz</li>
+<li><input disabled="" type="checkbox"> bar</li>
+<li><input checked="" disabled="" type="checkbox"> baz</li>
 </ul>
 </li>
-<li><input type="checkbox" disabled="" /> bim</li>
+<li><input disabled="" type="checkbox"> bim</li>
 </ul>
 <p>Show a regular (non task) list to show that it has the same structure</p>
 <ul>

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -1,0 +1,920 @@
+---
+title: Extensions test
+author: Yuki Izumi
+version: 0.1
+date: '2016-08-31'
+license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
+...
+
+## Tables
+
+Here's a well-formed table, doing everything it should.
+
+```````````````````````````````` example
+| abc | def |
+| --- | --- |
+| ghi | jkl |
+| mno | pqr |
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ghi</td>
+<td>jkl</td>
+</tr>
+<tr>
+<td>mno</td>
+<td>pqr</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+We're going to mix up the table now; we'll demonstrate that inline formatting
+works fine, but block elements don't.  You can also have empty cells, and the
+textual alignment of the columns is shown to be irrelevant.
+
+```````````````````````````````` example
+Hello!
+
+| _abc_ | セン |
+| ----- | ---- |
+| 1. Block elements inside cells don't work. | |
+| But _**inline elements do**_. | x |
+
+Hi!
+.
+<p>Hello!</p>
+<table>
+<thead>
+<tr>
+<th><em>abc</em></th>
+<th>セン</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1. Block elements inside cells don't work.</td>
+<td></td>
+</tr>
+<tr>
+<td>But <em><strong>inline elements do</strong></em>.</td>
+<td>x</td>
+</tr>
+</tbody>
+</table>
+<p>Hi!</p>
+````````````````````````````````
+
+Here we demonstrate some edge cases about what is and isn't a table.
+
+```````````````````````````````` example
+| Not enough table | to be considered table |
+
+| Not enough table | to be considered table |
+| Not enough table | to be considered table |
+
+| Just enough table | to be considered table |
+| ----------------- | ---------------------- |
+
+| ---- | --- |
+
+|x|
+|-|
+
+| xyz |
+| --- |
+.
+<p>| Not enough table | to be considered table |</p>
+<p>| Not enough table | to be considered table |
+| Not enough table | to be considered table |</p>
+<table>
+<thead>
+<tr>
+<th>Just enough table</th>
+<th>to be considered table</th>
+</tr>
+</thead>
+</table>
+<p>| ---- | --- |</p>
+<table>
+<thead>
+<tr>
+<th>x</th>
+</tr>
+</thead>
+</table>
+<table>
+<thead>
+<tr>
+<th>xyz</th>
+</tr>
+</thead>
+</table>
+````````````````````````````````
+
+A "simpler" table, GFM style:
+
+```````````````````````````````` example
+abc | def
+--- | ---
+xyz | ghi
+.
+<table>
+<thead>
+<tr>
+<th>abc</th>
+<th>def</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>xyz</td>
+<td>ghi</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+We are making the parser slighly more lax here. Here is a table with spaces at
+the end:
+
+```````````````````````````````` example
+Hello!
+
+| _abc_ | セン |
+| ----- | ---- |
+| this row has a space at the end | | 
+| But _**inline elements do**_. | x |
+
+Hi!
+.
+<p>Hello!</p>
+<table>
+<thead>
+<tr>
+<th><em>abc</em></th>
+<th>セン</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>this row has a space at the end</td>
+<td></td>
+</tr>
+<tr>
+<td>But <em><strong>inline elements do</strong></em>.</td>
+<td>x</td>
+</tr>
+</tbody>
+</table>
+<p>Hi!</p>
+````````````````````````````````
+
+Table alignment:
+
+```````````````````````````````` example
+aaa | bbb | ccc | ddd | eee
+:-- | --- | :-: | --- | --:
+fff | ggg | hhh | iii | jjj
+.
+<table>
+<thead>
+<tr>
+<th align="left">aaa</th>
+<th>bbb</th>
+<th align="center">ccc</th>
+<th>ddd</th>
+<th align="right">eee</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">fff</td>
+<td>ggg</td>
+<td align="center">hhh</td>
+<td>iii</td>
+<td align="right">jjj</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+### Table cell count mismatches
+
+The header and delimiter row must match.
+
+```````````````````````````````` example
+| a | b | c |
+| --- | --- |
+| this | isn't | okay |
+.
+<p>| a | b | c |
+| --- | --- |
+| this | isn't | okay |</p>
+````````````````````````````````
+
+But any of the body rows can be shorter. Rows longer
+than the header are truncated.
+
+```````````````````````````````` example
+| a | b | c |
+| --- | --- | ---
+| x
+| a | b
+| 1 | 2 | 3 | 4 | 5 |
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+<th>c</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>x</td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>a</td>
+<td>b</td>
+<td></td>
+</tr>
+<tr>
+<td>1</td>
+<td>2</td>
+<td>3</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+### Embedded pipes
+
+Tables with embedded pipes could be tricky.
+
+```````````````````````````````` example
+| a | b |
+| --- | --- |
+| Escaped pipes are \|okay\|. | Like \| this. |
+| Within `\|code\| is okay` too. |
+| _**`c\|`**_ \| complex
+| don't **\_reparse\_**
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Escaped pipes are |okay|.</td>
+<td>Like | this.</td>
+</tr>
+<tr>
+<td>Within <code>|code| is okay</code> too.</td>
+<td></td>
+</tr>
+<tr>
+<td><em><strong><code>c|</code></strong></em> | complex</td>
+<td></td>
+</tr>
+<tr>
+<td>don't <strong>_reparse_</strong></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+### Oddly-formatted markers
+
+This shouldn't assert.
+
+```````````````````````````````` example
+| a |
+--- |
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+</tr>
+</thead>
+</table>
+````````````````````````````````
+
+### Escaping
+
+```````````````````````````````` example
+| a | b |
+| --- | --- |
+| \\ | `\\` |
+| \\\\ | `\\\\` |
+| \_ | `\_` |
+| \| | `\|` |
+| \a | `\a` |
+
+\\ `\\`
+
+\\\\ `\\\\`
+
+\_ `\_`
+
+\| `\|`
+
+\a `\a`
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>\</td>
+<td><code>\\</code></td>
+</tr>
+<tr>
+<td>\\</td>
+<td><code>\\\\</code></td>
+</tr>
+<tr>
+<td>_</td>
+<td><code>\_</code></td>
+</tr>
+<tr>
+<td>|</td>
+<td><code>|</code></td>
+</tr>
+<tr>
+<td>\a</td>
+<td><code>\a</code></td>
+</tr>
+</tbody>
+</table>
+<p>\ <code>\\</code></p>
+<p>\\ <code>\\\\</code></p>
+<p>_ <code>\_</code></p>
+<p>| <code>\|</code></p>
+<p>\a <code>\a</code></p>
+````````````````````````````````
+
+### Embedded HTML
+
+```````````````````````````````` example
+| a |
+| --- |
+| <strong>hello</strong> |
+| ok <br> sure |
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>hello</strong></td>
+</tr>
+<tr>
+<td>ok <br> sure</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+### Reference-style links
+
+```````````````````````````````` example
+Here's a link to [Freedom Planet 2][].
+
+| Here's a link to [Freedom Planet 2][] in a table header. |
+| --- |
+| Here's a link to [Freedom Planet 2][] in a table row. |
+
+[Freedom Planet 2]: http://www.freedomplanet2.com/
+.
+<p>Here's a link to <a href="http://www.freedomplanet2.com/">Freedom Planet 2</a>.</p>
+<table>
+<thead>
+<tr>
+<th>Here's a link to <a href="http://www.freedomplanet2.com/">Freedom Planet 2</a> in a table header.</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Here's a link to <a href="http://www.freedomplanet2.com/">Freedom Planet 2</a> in a table row.</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+### Sequential cells
+
+```````````````````````````````` example
+| a | b | c |
+| --- | --- | --- |
+| d || e |
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+<th>c</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>d</td>
+<td></td>
+<td>e</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+### Interaction with emphasis
+
+```````````````````````````````` example
+| a | b |
+| --- | --- |
+|***(a)***|
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><em><strong>(a)</strong></em></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+### a table can be recognised when separated from a paragraph of text without an empty line
+
+```````````````````````````````` example
+123
+456
+| a | b |
+| ---| --- |
+d | e
+.
+<p>123
+456</p>
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>d</td>
+<td>e</td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+## Strikethroughs
+
+A well-formed strikethrough.
+
+```````````````````````````````` example
+A proper ~strikethrough~.
+.
+<p>A proper <del>strikethrough</del>.</p>
+````````````````````````````````
+
+Some strikethrough edge cases.
+
+```````````````````````````````` example
+These are ~not strikethroughs.
+
+No, they are not~
+
+This ~is ~ legit~ isn't ~ legit.
+
+This is not ~~~~~one~~~~~ huge strikethrough.
+
+~one~ ~~two~~ ~~~three~~~
+
+No ~mismatch~~
+.
+<p>These are ~not strikethroughs.</p>
+<p>No, they are not~</p>
+<p>This <del>is ~ legit</del> isn't ~ legit.</p>
+<p>This is not ~~~~~one~~~~~ huge strikethrough.</p>
+<p><del>one</del> <del>two</del> ~~~three~~~</p>
+<p>No ~mismatch~~</p>
+````````````````````````````````
+
+Using 200 tilde since it overflows the internal buffer
+size (100) for parsing delimiters in inlines.c
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~striked~
+
+## Autolinks
+
+```````````````````````````````` example
+: http://google.com https://google.com
+
+<http://google.com/å> http://google.com/å
+
+scyther@pokemon.com
+
+scy.the_rbe-edr+ill@pokemon.com
+
+scyther@pokemon.com.
+
+scyther@pokemon.com/
+
+scyther@pokemon.com/beedrill@pokemon.com
+
+mailto:scyther@pokemon.com
+
+This is a mailto:scyther@pokemon.com
+
+mailto:scyther@pokemon.com.
+
+mmmmailto:scyther@pokemon.com
+
+mailto:scyther@pokemon.com/
+
+mailto:scyther@pokemon.com/message
+
+mailto:scyther@pokemon.com/mailto:beedrill@pokemon.com
+
+xmpp:scyther@pokemon.com
+
+xmpp:scyther@pokemon.com.
+
+xmpp:scyther@pokemon.com/message
+
+xmpp:scyther@pokemon.com/message.
+
+Email me at:scyther@pokemon.com
+
+www.github.com www.github.com/á
+
+www.google.com/a_b
+
+Underscores not allowed in host name www.xxx.yyy._zzz
+
+Underscores not allowed in host name www.xxx._yyy.zzz
+
+Underscores allowed in domain name www._xxx.yyy.zzz
+
+**Autolink and http://inlines**
+
+![http://inline.com/image](http://inline.com/image)
+
+a.w@b.c
+
+Full stop outside parens shouldn't be included http://google.com/ok.
+
+(Full stop inside parens shouldn't be included http://google.com/ok.)
+
+"http://google.com"
+
+'http://google.com'
+
+http://🍄.ga/ http://x🍄.ga/
+.
+<p>: <a href="http://google.com">http://google.com</a> <a href="https://google.com">https://google.com</a></p>
+<p><a href="http://google.com/%C3%A5">http://google.com/å</a> <a href="http://google.com/%C3%A5">http://google.com/å</a></p>
+<p><a href="mailto:scyther@pokemon.com">scyther@pokemon.com</a></p>
+<p><a href="mailto:scy.the_rbe-edr+ill@pokemon.com">scy.the_rbe-edr+ill@pokemon.com</a></p>
+<p><a href="mailto:scyther@pokemon.com">scyther@pokemon.com</a>.</p>
+<p><a href="mailto:scyther@pokemon.com">scyther@pokemon.com</a>/</p>
+<p><a href="mailto:scyther@pokemon.com">scyther@pokemon.com</a>/<a href="mailto:beedrill@pokemon.com">beedrill@pokemon.com</a></p>
+<p><a href="mailto:scyther@pokemon.com">mailto:scyther@pokemon.com</a></p>
+<p>This is a <a href="mailto:scyther@pokemon.com">mailto:scyther@pokemon.com</a></p>
+<p><a href="mailto:scyther@pokemon.com">mailto:scyther@pokemon.com</a>.</p>
+<p>mmmmailto:<a href="mailto:scyther@pokemon.com">scyther@pokemon.com</a></p>
+<p><a href="mailto:scyther@pokemon.com">mailto:scyther@pokemon.com</a>/</p>
+<p><a href="mailto:scyther@pokemon.com">mailto:scyther@pokemon.com</a>/message</p>
+<p><a href="mailto:scyther@pokemon.com">mailto:scyther@pokemon.com</a>/<a href="mailto:beedrill@pokemon.com">mailto:beedrill@pokemon.com</a></p>
+<p><a href="xmpp:scyther@pokemon.com">xmpp:scyther@pokemon.com</a></p>
+<p><a href="xmpp:scyther@pokemon.com">xmpp:scyther@pokemon.com</a>.</p>
+<p><a href="xmpp:scyther@pokemon.com/message">xmpp:scyther@pokemon.com/message</a></p>
+<p><a href="xmpp:scyther@pokemon.com/message">xmpp:scyther@pokemon.com/message</a>.</p>
+<p>Email me at:<a href="mailto:scyther@pokemon.com">scyther@pokemon.com</a></p>
+<p><a href="http://www.github.com">www.github.com</a> <a href="http://www.github.com/%C3%A1">www.github.com/á</a></p>
+<p><a href="http://www.google.com/a_b">www.google.com/a_b</a></p>
+<p>Underscores not allowed in host name www.xxx.yyy._zzz</p>
+<p>Underscores not allowed in host name www.xxx._yyy.zzz</p>
+<p>Underscores allowed in domain name <a href="http://www._xxx.yyy.zzz">www._xxx.yyy.zzz</a></p>
+<p><strong>Autolink and <a href="http://inlines">http://inlines</a></strong></p>
+<p><img src="http://inline.com/image" alt="http://inline.com/image" /></p>
+<p><a href="mailto:a.w@b.c">a.w@b.c</a></p>
+<p>Full stop outside parens shouldn't be included <a href="http://google.com/ok">http://google.com/ok</a>.</p>
+<p>(Full stop inside parens shouldn't be included <a href="http://google.com/ok">http://google.com/ok</a>.)</p>
+<p>&quot;<a href="http://google.com">http://google.com</a>&quot;</p>
+<p>'<a href="http://google.com">http://google.com</a>'</p>
+<p><a href="http://%F0%9F%8D%84.ga/">http://🍄.ga/</a> <a href="http://x%F0%9F%8D%84.ga/">http://x🍄.ga/</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+This shouldn't crash everything: (_A_@_.A
+.
+<IGNORE>
+````````````````````````````````
+
+```````````````````````````````` example
+These should not link:
+
+* @a.b.c@. x
+* n@.  b
+.
+<p>These should not link:</p>
+<ul>
+<li>@a.b.c@. x</li>
+<li>n@.  b</li>
+</ul>
+````````````````````````````````
+
+## HTML tag filter
+
+
+```````````````````````````````` example tagfilter
+This is <xmp> not okay, but **this** <strong>is</strong>.
+
+<p>This is <xmp> not okay, but **this** <strong>is</strong>.</p>
+
+Nope, I won't have <textarea>.
+
+<p>No <textarea> here either.</p>
+
+<p>This <random /> <thing> is okay</thing> though.</p>
+
+Yep, <totally>okay</totally>.
+
+<!-- HTML comments are okay, though. -->
+<!- But we're strict. ->
+<! No nonsense. >
+<!-- Leave multiline comments the heck alone, though, okay?
+Even with {"x":"y"} or 1 > 2 or whatever. Even **markdown**.
+-->
+<!--- Support everything CommonMark's parser does. -->
+<!---->
+<!--thistoo-->
+.
+<p>This is &lt;xmp> not okay, but <strong>this</strong> <strong>is</strong>.</p>
+<p>This is &lt;xmp> not okay, but **this** <strong>is</strong>.</p>
+<p>Nope, I won't have &lt;textarea>.</p>
+<p>No &lt;textarea> here either.</p>
+<p>This <random /> <thing> is okay</thing> though.</p>
+<p>Yep, <totally>okay</totally>.</p>
+<!-- HTML comments are okay, though. -->
+<p>&lt;!- But we're strict. -&gt;
+&lt;! No nonsense. &gt;</p>
+<!-- Leave multiline comments the heck alone, though, okay?
+Even with {"x":"y"} or 1 > 2 or whatever. Even **markdown**.
+-->
+<!--- Support everything CommonMark's parser does. -->
+<!---->
+<!--thistoo-->
+````````````````````````````````
+
+## Footnotes
+
+```````````````````````````````` example
+This is some text![^1]. Other text.[^footnote].
+
+Here's a thing[^other-note].
+
+And another thing[^codeblock-note].
+
+This doesn't have a referent[^nope].
+
+
+[^other-note]:       no code block here (spaces are stripped away)
+
+[^codeblock-note]:
+        this is now a code block (8 spaces indentation)
+
+[^1]: Some *bolded* footnote definition.
+
+Hi!
+
+[^footnote]:
+    > Blockquotes can be in a footnote.
+
+        as well as code blocks
+
+    or, naturally, simple paragraphs.
+
+[^unused]: This is unused.
+.
+<p>This is some text!<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>. Other text.<sup class="footnote-ref"><a href="#fn-footnote" id="fnref-footnote" data-footnote-ref>2</a></sup>.</p>
+<p>Here's a thing<sup class="footnote-ref"><a href="#fn-other-note" id="fnref-other-note" data-footnote-ref>3</a></sup>.</p>
+<p>And another thing<sup class="footnote-ref"><a href="#fn-codeblock-note" id="fnref-codeblock-note" data-footnote-ref>4</a></sup>.</p>
+<p>This doesn't have a referent[^nope].</p>
+<p>Hi!</p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-1">
+<p>Some <em>bolded</em> footnote definition. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+<li id="fn-footnote">
+<blockquote>
+<p>Blockquotes can be in a footnote.</p>
+</blockquote>
+<pre><code>as well as code blocks
+</code></pre>
+<p>or, naturally, simple paragraphs. <a href="#fnref-footnote" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+</li>
+<li id="fn-other-note">
+<p>no code block here (spaces are stripped away) <a href="#fnref-other-note" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="3" aria-label="Back to reference 3">↩</a></p>
+</li>
+<li id="fn-codeblock-note">
+<pre><code>this is now a code block (8 spaces indentation)
+</code></pre>
+<a href="#fnref-codeblock-note" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="4" aria-label="Back to reference 4">↩</a>
+</li>
+</ol>
+</section>
+````````````````````````````````
+
+## When a footnote is used multiple times, we insert multiple backrefs.
+
+```````````````````````````````` example
+This is some text. It has a footnote[^a-footnote].
+
+This footnote is referenced[^a-footnote] multiple times, in lots of different places.[^a-footnote]
+
+[^a-footnote]: This footnote definition should have three backrefs.
+.
+<p>This is some text. It has a footnote<sup class="footnote-ref"><a href="#fn-a-footnote" id="fnref-a-footnote" data-footnote-ref>1</a></sup>.</p>
+<p>This footnote is referenced<sup class="footnote-ref"><a href="#fn-a-footnote" id="fnref-a-footnote-2" data-footnote-ref>1</a></sup> multiple times, in lots of different places.<sup class="footnote-ref"><a href="#fn-a-footnote" id="fnref-a-footnote-3" data-footnote-ref>1</a></sup></p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-a-footnote">
+<p>This footnote definition should have three backrefs. <a href="#fnref-a-footnote" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-a-footnote-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a> <a href="#fnref-a-footnote-3" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-3" aria-label="Back to reference 1-3">↩<sup class="footnote-ref">3</sup></a></p>
+</li>
+</ol>
+</section>
+````````````````````````````````
+
+## Footnote reference labels are href escaped
+
+```````````````````````````````` example
+Hello[^"><script>alert(1)</script>]
+
+[^"><script>alert(1)</script>]: pwned
+.
+<p>Hello<sup class="footnote-ref"><a href="#fn-%22%3E%3Cscript%3Ealert(1)%3C/script%3E" id="fnref-%22%3E%3Cscript%3Ealert(1)%3C/script%3E" data-footnote-ref>1</a></sup></p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-%22%3E%3Cscript%3Ealert(1)%3C/script%3E">
+<p>pwned <a href="#fnref-%22%3E%3Cscript%3Ealert(1)%3C/script%3E" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+</ol>
+</section>
+````````````````````````````````
+
+## Interop
+
+Autolink and strikethrough.
+
+```````````````````````````````` example
+~~www.google.com~~
+
+~~http://google.com~~
+.
+<p><del><a href="http://www.google.com">www.google.com</a></del></p>
+<p><del><a href="http://google.com">http://google.com</a></del></p>
+````````````````````````````````
+
+Autolink and tables.
+
+```````````````````````````````` example
+| a | b |
+| --- | --- |
+| https://github.com www.github.com | http://pokemon.com |
+.
+<table>
+<thead>
+<tr>
+<th>a</th>
+<th>b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="https://github.com">https://github.com</a> <a href="http://www.github.com">www.github.com</a></td>
+<td><a href="http://pokemon.com">http://pokemon.com</a></td>
+</tr>
+</tbody>
+</table>
+````````````````````````````````
+
+## Task lists
+
+```````````````````````````````` example
+- [ ] foo
+- [x] bar
+.
+<ul>
+<li><input type="checkbox" disabled="" /> foo</li>
+<li><input type="checkbox" checked="" disabled="" /> bar</li>
+</ul>
+````````````````````````````````
+
+Show that a task list and a regular list get processed the same in
+the way that sublists are created. If something works in a list
+item, then it should work the same way with a task.  The only
+difference should be the tasklist marker. So, if we use something
+other than a space or x, it won't be recognized as a task item, and
+so will be treated as a regular item.
+
+```````````````````````````````` example
+- [x] foo
+  - [ ] bar
+  - [x] baz
+- [ ] bim
+
+Show a regular (non task) list to show that it has the same structure
+- [@] foo
+  - [@] bar
+  - [@] baz
+- [@] bim
+.
+<ul>
+<li><input type="checkbox" checked="" disabled="" /> foo
+<ul>
+<li><input type="checkbox" disabled="" /> bar</li>
+<li><input type="checkbox" checked="" disabled="" /> baz</li>
+</ul>
+</li>
+<li><input type="checkbox" disabled="" /> bim</li>
+</ul>
+<p>Show a regular (non task) list to show that it has the same structure</p>
+<ul>
+<li>[@] foo
+<ul>
+<li>[@] bar</li>
+<li>[@] baz</li>
+</ul>
+</li>
+<li>[@] bim</li>
+</ul>
+````````````````````````````````
+Use a larger indent -- a task list and a regular list should produce
+the same structure.
+
+```````````````````````````````` example
+- [x] foo
+    - [ ] bar
+    - [x] baz
+- [ ] bim
+
+Show a regular (non task) list to show that it has the same structure
+- [@] foo
+    - [@] bar
+    - [@] baz
+- [@] bim
+.
+<ul>
+<li><input type="checkbox" checked="" disabled="" /> foo
+<ul>
+<li><input type="checkbox" disabled="" /> bar</li>
+<li><input type="checkbox" checked="" disabled="" /> baz</li>
+</ul>
+</li>
+<li><input type="checkbox" disabled="" /> bim</li>
+</ul>
+<p>Show a regular (non task) list to show that it has the same structure</p>
+<ul>
+<li>[@] foo
+<ul>
+<li>[@] bar</li>
+<li>[@] baz</li>
+</ul>
+</li>
+<li>[@] bim</li>
+</ul>
+````````````````````````````````

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -511,7 +511,7 @@ A proper ~strikethrough~.
 
 Some strikethrough edge cases.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 These are ~not strikethroughs.
 
 No, they are not~

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -10,7 +10,7 @@ license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
 
 Here's a well-formed table, doing everything it should.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | abc | def |
 | --- | --- |
 | ghi | jkl |
@@ -40,7 +40,7 @@ We're going to mix up the table now; we'll demonstrate that inline formatting
 works fine, but block elements don't.  You can also have empty cells, and the
 textual alignment of the columns is shown to be irrelevant.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 Hello!
 
 | _abc_ | セン |
@@ -74,7 +74,7 @@ Hi!
 
 Here we demonstrate some edge cases about what is and isn't a table.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | Not enough table | to be considered table |
 
 | Not enough table | to be considered table |
@@ -121,7 +121,7 @@ Here we demonstrate some edge cases about what is and isn't a table.
 
 A "simpler" table, GFM style:
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 abc | def
 --- | ---
 xyz | ghi
@@ -145,7 +145,7 @@ xyz | ghi
 We are making the parser slighly more lax here. Here is a table with spaces at
 the end:
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 Hello!
 
 | _abc_ | セン |
@@ -179,7 +179,7 @@ Hi!
 
 Table alignment:
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 aaa | bbb | ccc | ddd | eee
 :-- | --- | :-: | --- | --:
 fff | ggg | hhh | iii | jjj
@@ -223,7 +223,7 @@ The header and delimiter row must match.
 But any of the body rows can be shorter. Rows longer
 than the header are truncated.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b | c |
 | --- | --- | ---
 | x
@@ -262,7 +262,7 @@ than the header are truncated.
 
 Tables with embedded pipes could be tricky.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b |
 | --- | --- |
 | Escaped pipes are \|okay\|. | Like \| this. |
@@ -302,7 +302,7 @@ Tables with embedded pipes could be tricky.
 
 This shouldn't assert.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a |
 --- |
 .
@@ -317,7 +317,7 @@ This shouldn't assert.
 
 ### Escaping
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b |
 | --- | --- |
 | \\ | `\\` |
@@ -375,7 +375,7 @@ This shouldn't assert.
 
 ### Embedded HTML
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a |
 | --- |
 | <strong>hello</strong> |
@@ -400,7 +400,7 @@ This shouldn't assert.
 
 ### Reference-style links
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 Here's a link to [Freedom Planet 2][].
 
 | Here's a link to [Freedom Planet 2][] in a table header. |
@@ -426,7 +426,7 @@ Here's a link to [Freedom Planet 2][].
 
 ### Sequential cells
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b | c |
 | --- | --- | --- |
 | d || e |
@@ -451,7 +451,7 @@ Here's a link to [Freedom Planet 2][].
 
 ### Interaction with emphasis
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b |
 | --- | --- |
 |***(a)***|
@@ -474,7 +474,7 @@ Here's a link to [Freedom Planet 2][].
 
 ### a table can be recognised when separated from a paragraph of text without an empty line
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 123
 456
 | a | b |
@@ -511,7 +511,7 @@ A proper ~strikethrough~.
 
 Some strikethrough edge cases.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 These are ~not strikethroughs.
 
 No, they are not~
@@ -538,7 +538,7 @@ size (100) for parsing delimiters in inlines.c
 
 ## Autolinks
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 : http://google.com https://google.com
 
 <http://google.com/å> http://google.com/å
@@ -637,7 +637,7 @@ http://🍄.ga/ http://x🍄.ga/
 <p><a href="http://%F0%9F%8D%84.ga/">http://🍄.ga/</a> <a href="http://x%F0%9F%8D%84.ga/">http://x🍄.ga/</a></p>
 ````````````````````````````````
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 This shouldn't crash everything: (_A_@_.A
 .
 <IGNORE>
@@ -701,7 +701,7 @@ Even with {"x":"y"} or 1 > 2 or whatever. Even **markdown**.
 
 ## Footnotes
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 This is some text![^1]. Other text.[^footnote].
 
 Here's a thing[^other-note].
@@ -761,7 +761,7 @@ Hi!
 
 ## When a footnote is used multiple times, we insert multiple backrefs.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 This is some text. It has a footnote[^a-footnote].
 
 This footnote is referenced[^a-footnote] multiple times, in lots of different places.[^a-footnote]
@@ -781,7 +781,7 @@ This footnote is referenced[^a-footnote] multiple times, in lots of different pl
 
 ## Footnote reference labels are href escaped
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 Hello[^"><script>alert(1)</script>]
 
 [^"><script>alert(1)</script>]: pwned
@@ -800,7 +800,7 @@ Hello[^"><script>alert(1)</script>]
 
 Autolink and strikethrough.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 ~~www.google.com~~
 
 ~~http://google.com~~
@@ -811,7 +811,7 @@ Autolink and strikethrough.
 
 Autolink and tables.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b |
 | --- | --- |
 | https://github.com www.github.com | http://pokemon.com |

--- a/spec/fixtures/gfm-extra.txt
+++ b/spec/fixtures/gfm-extra.txt
@@ -1,9 +1,0 @@
-## Strikethrough
-
-Don't strikethrough with only one tilde.
-
-```````````````````````````````` example gfm
-~hello~
-.
-<p>~hello~</p>
-````````````````````````````````

--- a/spec/fixtures/gfm-regression.txt
+++ b/spec/fixtures/gfm-regression.txt
@@ -1,0 +1,376 @@
+### Regression tests
+
+Issue #113: EOL character weirdness on Windows
+(Important: first line ends with CR + CR + LF)
+
+```````````````````````````````` example
+line1
+
+line2
+.
+<p>line1</p>
+<p>line2</p>
+````````````````````````````````
+
+Issue #114: cmark skipping first character in line
+(Important: the blank lines around "Repeatedly" contain a tab.)
+
+```````````````````````````````` example
+By taking it apart
+
+- alternative solutions
+→
+Repeatedly solving
+→
+- how techniques
+.
+<p>By taking it apart</p>
+<ul>
+<li>alternative solutions</li>
+</ul>
+<p>Repeatedly solving</p>
+<ul>
+<li>how techniques</li>
+</ul>
+````````````````````````````````
+
+Issue jgm/CommonMark#430:  h2..h6 not recognized as block tags.
+
+```````````````````````````````` example
+<h1>lorem</h1>
+
+<h2>lorem</h2>
+
+<h3>lorem</h3>
+
+<h4>lorem</h4>
+
+<h5>lorem</h5>
+
+<h6>lorem</h6>
+.
+<h1>lorem</h1>
+<h2>lorem</h2>
+<h3>lorem</h3>
+<h4>lorem</h4>
+<h5>lorem</h5>
+<h6>lorem</h6>
+````````````````````````````````
+
+Issue jgm/commonmark.js#109 - tabs after setext header line
+
+
+```````````````````````````````` example
+hi
+--→
+.
+<h2>hi</h2>
+````````````````````````````````
+
+Issue #177 - incorrect emphasis parsing
+
+```````````````````````````````` example
+a***b* c*
+.
+<p>a*<em><em>b</em> c</em></p>
+````````````````````````````````
+
+Issue #193 - unescaped left angle brackets in link destination
+
+```````````````````````````````` example
+[a]
+
+[a]: <te<st>
+.
+<p>[a]</p>
+<p>[a]: &lt;te<st></p>
+````````````````````````````````
+
+Issue #192 - escaped spaces in link destination
+
+
+```````````````````````````````` example
+[a](te\ st)
+.
+<p>[a](te\ st)</p>
+````````````````````````````````
+
+Issue github/github#76615:  multiple delimiter combinations gets sketchy
+
+
+```````````````````````````````` example strikethrough
+~~**_`this`_**~~  
+~~***`this`***~~  
+~~___`this`___~~
+
+**_`this`_**  
+***`this`***  
+___`this`___
+
+~~**_this_**~~  
+~~***this***~~  
+~~___this___~~
+
+**_this_**  
+***this***  
+___this___
+.
+<p><del><strong><em><code>this</code></em></strong></del><br />
+<del><em><strong><code>this</code></strong></em></del><br />
+<del><em><strong><code>this</code></strong></em></del></p>
+<p><strong><em><code>this</code></em></strong><br />
+<em><strong><code>this</code></strong></em><br />
+<em><strong><code>this</code></strong></em></p>
+<p><del><strong><em>this</em></strong></del><br />
+<del><em><strong>this</strong></em></del><br />
+<del><em><strong>this</strong></em></del></p>
+<p><strong><em>this</em></strong><br />
+<em><strong>this</strong></em><br />
+<em><strong>this</strong></em></p>
+````````````````````````````````
+
+Issue #527 - meta tags in inline contexts
+
+```````````````````````````````` example
+City:
+<span itemprop="contentLocation" itemscope itemtype="https://schema.org/City">
+  <meta itemprop="name" content="Springfield">
+</span>
+.
+<p>City:
+<span itemprop="contentLocation" itemscope itemtype="https://schema.org/City">
+<meta itemprop="name" content="Springfield">
+</span></p>
+````````````````````````````````
+
+cmark-gfm strikethrough rules
+
+```````````````````````````````` example strikethrough
+~Hi~ Hello, world!
+.
+<p><del>Hi</del> Hello, world!</p>
+````````````````````````````````
+
+```````````````````````````````` example strikethrough
+This ~text~ ~~is~~ ~~~curious~~~.
+.
+<p>This <del>text</del> <del>is</del> ~~~curious~~~.</p>
+````````````````````````````````
+
+`~` should not be escaped in href — https://github.com/github/markup/issues/311
+
+```````````````````````````````` example
+[x](http://members.aon.at/~nkehrer/ibm_5110/emu5110.html)
+.
+<p><a href="http://members.aon.at/~nkehrer/ibm_5110/emu5110.html">x</a></p>
+````````````````````````````````
+
+Footnotes in tables
+
+```````````````````````````````` example table footnotes
+A footnote in a paragraph[^1]
+
+| Column1   | Column2 |
+| --------- | ------- |
+| foot [^1] | note    |
+
+[^1]: a footnote
+.
+<p>A footnote in a paragraph<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup></p>
+<table>
+<thead>
+<tr>
+<th>Column1</th>
+<th>Column2</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>foot <sup class="footnote-ref"><a href="#fn-1" id="fnref-1-2" data-footnote-ref>1</a></sup></td>
+<td>note</td>
+</tr>
+</tbody>
+</table>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-1">
+<p>a footnote <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a> <a href="#fnref-1-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1-2" aria-label="Back to reference 1-2">↩<sup class="footnote-ref">2</sup></a></p>
+</li>
+</ol>
+</section>
+````````````````````````````````
+
+Issue #527 - meta tags in inline contexts
+
+```````````````````````````````` example
+City:
+<span itemprop="contentLocation" itemscope itemtype="https://schema.org/City">
+  <meta itemprop="name" content="Springfield">
+</span>
+.
+<p>City:
+<span itemprop="contentLocation" itemscope itemtype="https://schema.org/City">
+<meta itemprop="name" content="Springfield">
+</span></p>
+````````````````````````````````
+
+Issue #530 - link parsing corner cases
+
+```````````````````````````````` example
+[a](\ b)
+
+[a](<<b)
+
+[a](<b
+)
+.
+<p>[a](\ b)</p>
+<p>[a](&lt;&lt;b)</p>
+<p>[a](&lt;b
+)</p>
+````````````````````````````````
+
+Issue commonmark#526 - unescaped ( in link title
+
+```````````````````````````````` example
+[link](url ((title))
+.
+<p>[link](url ((title))</p>
+````````````````````````````````
+
+Issue commonamrk#517 - script, pre, style close tag without
+opener.
+
+```````````````````````````````` example
+</script>
+
+</pre>
+
+</style>
+.
+</script>
+</pre>
+</style>
+````````````````````````````````
+
+Issue #289.
+
+```````````````````````````````` example
+[a](<b) c>
+.
+<p>[a](&lt;b) c&gt;</p>
+````````````````````````````````
+
+Pull request #128 - Buffer overread in tables extension
+
+```````````````````````````````` example table
+|
+-|
+.
+<p>|
+-|</p>
+````````````````````````````````
+
+Footnotes may be nested inside other footnotes.
+
+```````````````````````````````` example footnotes
+This is some text. It has a citation.[^citation]
+
+[^another-citation]: My second citation.
+
+[^citation]: This is a long winded parapgraph that also has another citation.[^another-citation]
+.
+<p>This is some text. It has a citation.<sup class="footnote-ref"><a href="#fn-citation" id="fnref-citation" data-footnote-ref>1</a></sup></p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-citation">
+<p>This is a long winded parapgraph that also has another citation.<sup class="footnote-ref"><a href="#fn-another-citation" id="fnref-another-citation" data-footnote-ref>2</a></sup> <a href="#fnref-citation" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+<li id="fn-another-citation">
+<p>My second citation. <a href="#fnref-another-citation" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+</li>
+</ol>
+</section>
+````````````````````````````````
+
+Footnotes are similar to, but should not be confused with, link references
+
+```````````````````````````````` example footnotes
+This is some text. It has two footnotes references, side-by-side without any spaces,[^footnote1][^footnote2] which are definitely not link references.
+
+[^footnote1]: Hello.
+
+[^footnote2]: Goodbye.
+.
+<p>This is some text. It has two footnotes references, side-by-side without any spaces,<sup class="footnote-ref"><a href="#fn-footnote1" id="fnref-footnote1" data-footnote-ref>1</a></sup><sup class="footnote-ref"><a href="#fn-footnote2" id="fnref-footnote2" data-footnote-ref>2</a></sup> which are definitely not link references.</p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-footnote1">
+<p>Hello. <a href="#fnref-footnote1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+<li id="fn-footnote2">
+<p>Goodbye. <a href="#fnref-footnote2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+</li>
+</ol>
+</section>
+````````````````````````````````
+
+Footnotes may begin with or have a 'w' or a '_' in their reference label.
+
+```````````````````````````````` example footnotes autolink
+This is some text. Sometimes the autolinker splits up text into multiple nodes, hoping it will find a hyperlink, so this text has a footnote whose reference label begins with a `w`.[^widely-cited]
+
+It has another footnote that contains many different characters (the autolinker was also breaking on `_`).[^sphinx-of-black-quartz_judge-my-vow-0123456789]
+
+[^sphinx-of-black-quartz_judge-my-vow-0123456789]: so does this.
+
+[^widely-cited]: this renders properly.
+.
+<p>This is some text. Sometimes the autolinker splits up text into multiple nodes, hoping it will find a hyperlink, so this text has a footnote whose reference label begins with a <code>w</code>.<sup class="footnote-ref"><a href="#fn-widely-cited" id="fnref-widely-cited" data-footnote-ref>1</a></sup></p>
+<p>It has another footnote that contains many different characters (the autolinker was also breaking on <code>_</code>).<sup class="footnote-ref"><a href="#fn-sphinx-of-black-quartz_judge-my-vow-0123456789" id="fnref-sphinx-of-black-quartz_judge-my-vow-0123456789" data-footnote-ref>2</a></sup></p>
+<section class="footnotes" data-footnotes>
+<ol>
+<li id="fn-widely-cited">
+<p>this renders properly. <a href="#fnref-widely-cited" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+<li id="fn-sphinx-of-black-quartz_judge-my-vow-0123456789">
+<p>so does this. <a href="#fnref-sphinx-of-black-quartz_judge-my-vow-0123456789" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+</li>
+</ol>
+</section>
+````````````````````````````````
+
+Footnotes interacting with strikethrough should not lead to a use-after-free
+
+```````````````````````````````` example footnotes autolink strikethrough table
+|Tot.....[^_a_]|
+.
+<p>|Tot.....[^_a_]|</p>
+````````````````````````````````
+
+Footnotes interacting with strikethrough should not lead to a use-after-free pt2
+
+```````````````````````````````` example footnotes autolink strikethrough table
+[^~~is~~1]
+.
+<p>[^~~is~~1]</p>
+````````````````````````````````
+
+Adjacent unused footnotes definitions should not lead to a use after free
+
+```````````````````````````````` example footnotes autolink strikethrough table
+Hello world
+
+
+[^a]:[^b]:
+.
+<p>Hello world</p>
+````````````````````````````````
+
+Issue #424 - emphasis before links
+
+```````````````````````````````` example
+*text* [link](#section)
+.
+<p><em>text</em> <a href="#section">link</a></p>
+````````````````````````````````

--- a/spec/fixtures/gfm-regression.txt
+++ b/spec/fixtures/gfm-regression.txt
@@ -151,7 +151,7 @@ cmark-gfm strikethrough rules
 <p><del>Hi</del> Hello, world!</p>
 ````````````````````````````````
 
-```````````````````````````````` example strikethrough pending
+```````````````````````````````` example strikethrough
 This ~text~ ~~is~~ ~~~curious~~~.
 .
 <p>This <del>text</del> <del>is</del> ~~~curious~~~.</p>

--- a/spec/fixtures/gfm-regression.txt
+++ b/spec/fixtures/gfm-regression.txt
@@ -151,7 +151,7 @@ cmark-gfm strikethrough rules
 <p><del>Hi</del> Hello, world!</p>
 ````````````````````````````````
 
-```````````````````````````````` example strikethrough
+```````````````````````````````` example strikethrough pending
 This ~text~ ~~is~~ ~~~curious~~~.
 .
 <p>This <del>text</del> <del>is</del> ~~~curious~~~.</p>
@@ -167,7 +167,7 @@ This ~text~ ~~is~~ ~~~curious~~~.
 
 Footnotes in tables
 
-```````````````````````````````` example table footnotes
+```````````````````````````````` example table footnotes pending
 A footnote in a paragraph[^1]
 
 | Column1   | Column2 |
@@ -232,7 +232,7 @@ Issue #530 - link parsing corner cases
 
 Issue commonmark#526 - unescaped ( in link title
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 [link](url ((title))
 .
 <p>[link](url ((title))</p>
@@ -273,7 +273,7 @@ Pull request #128 - Buffer overread in tables extension
 
 Footnotes may be nested inside other footnotes.
 
-```````````````````````````````` example footnotes
+```````````````````````````````` example footnotes pending
 This is some text. It has a citation.[^citation]
 
 [^another-citation]: My second citation.
@@ -295,7 +295,7 @@ This is some text. It has a citation.[^citation]
 
 Footnotes are similar to, but should not be confused with, link references
 
-```````````````````````````````` example footnotes
+```````````````````````````````` example footnotes pending
 This is some text. It has two footnotes references, side-by-side without any spaces,[^footnote1][^footnote2] which are definitely not link references.
 
 [^footnote1]: Hello.
@@ -317,7 +317,7 @@ This is some text. It has two footnotes references, side-by-side without any spa
 
 Footnotes may begin with or have a 'w' or a '_' in their reference label.
 
-```````````````````````````````` example footnotes autolink
+```````````````````````````````` example footnotes autolink pending
 This is some text. Sometimes the autolinker splits up text into multiple nodes, hoping it will find a hyperlink, so this text has a footnote whose reference label begins with a `w`.[^widely-cited]
 
 It has another footnote that contains many different characters (the autolinker was also breaking on `_`).[^sphinx-of-black-quartz_judge-my-vow-0123456789]
@@ -342,7 +342,7 @@ It has another footnote that contains many different characters (the autolinker 
 
 Footnotes interacting with strikethrough should not lead to a use-after-free
 
-```````````````````````````````` example footnotes autolink strikethrough table
+```````````````````````````````` example footnotes autolink strikethrough table pending
 |Tot.....[^_a_]|
 .
 <p>|Tot.....[^_a_]|</p>
@@ -350,7 +350,7 @@ Footnotes interacting with strikethrough should not lead to a use-after-free
 
 Footnotes interacting with strikethrough should not lead to a use-after-free pt2
 
-```````````````````````````````` example footnotes autolink strikethrough table
+```````````````````````````````` example footnotes autolink strikethrough table pending
 [^~~is~~1]
 .
 <p>[^~~is~~1]</p>

--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -6923,7 +6923,7 @@ foo__bar__
 ````````````````````````````````
 
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 __foo, __bar__, baz__
 .
 <p><strong>foo, bar, baz</strong></p>
@@ -7194,7 +7194,7 @@ foo***bar***baz
 <p>foo<em><strong>bar</strong></em>baz</p>
 ````````````````````````````````
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 foo******bar*********baz
 .
 <p>foo<strong>bar</strong>***baz</p>
@@ -7265,21 +7265,21 @@ __foo _bar_ baz__
 ````````````````````````````````
 
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 __foo __bar__ baz__
 .
 <p><strong>foo bar baz</strong></p>
 ````````````````````````````````
 
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 ____foo__ bar__
 .
 <p><strong>foo bar</strong></p>
 ````````````````````````````````
 
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 **foo **bar****
 .
 <p><strong>foo bar</strong></p>
@@ -7564,14 +7564,14 @@ _*foo*_
 However, strong emphasis within strong emphasis is possible without
 switching delimiters:
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 ****foo****
 .
 <p><strong>foo</strong></p>
 ````````````````````````````````
 
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 ____foo____
 .
 <p><strong>foo</strong></p>
@@ -7582,7 +7582,7 @@ ____foo____
 Rule 13 can be applied to arbitrarily long sequences of
 delimiters:
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 ******foo******
 .
 <p><strong>foo</strong></p>
@@ -7598,7 +7598,7 @@ Rule 14:
 ````````````````````````````````
 
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 _____foo_____
 .
 <p><em><strong>foo</strong></em></p>

--- a/spec/markd_spec.cr
+++ b/spec/markd_spec.cr
@@ -13,7 +13,9 @@ describe_spec("fixtures/emoji.txt")
 
 describe_spec("fixtures/gfm-spec.txt", gfm: true)
 
-describe_spec("fixtures/gfm-extra.txt", gfm: true)
+describe_spec("fixtures/gfm-extensions.txt", gfm: true)
+
+describe_spec("fixtures/gfm-regression.txt", gfm: true)
 
 describe Markd do
   # Thanks Ryan Westlund <rlwestlund@gmail.com> feedback via email.

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -25,7 +25,7 @@ module Markd::Parser
       end
 
       node.text = ""
-      process_emphasis(nil)
+      process_delimiters(nil)
     end
 
     private def process_line(node : Node)
@@ -270,7 +270,7 @@ module Markd::Parser
         end
 
         node.append_child(child)
-        process_emphasis(opener.previous_delimiter)
+        process_delimiters(opener.previous_delimiter)
         remove_bracket
         opener.node.unlink
 
@@ -290,7 +290,7 @@ module Markd::Parser
       true
     end
 
-    private def process_emphasis(delimiter : Delimiter?)
+    private def process_delimiters(delimiter : Delimiter?)
       # find first closer above stack_bottom:
       closer = @delimiters
       while closer

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -344,8 +344,6 @@ module Markd::Parser
                 # calculate actual number of delimiters used from closer
                 use_delims = (closer.num_delims >= 2 && opener.num_delims >= 2) ? 2 : 1
 
-                return if (closer_char == '~') && use_delims == 1
-
                 opener_inl = opener.node
                 closer_inl = closer.node
 

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -344,6 +344,15 @@ module Markd::Parser
                 # calculate actual number of delimiters used from closer
                 use_delims = (closer.num_delims >= 2 && opener.num_delims >= 2) ? 2 : 1
 
+                if closer_char == '~' && (
+                     closer.num_delims > 2 ||
+                     opener.num_delims > 2 ||
+                     closer.num_delims != opener.num_delims
+                   )
+                  closer = closer.next?
+                  next
+                end
+
                 opener_inl = opener.node
                 closer_inl = closer.node
 


### PR DESCRIPTION
- `gfm-spec.txt` was missing tests that are available on the website (see https://github.com/github/cmark-gfm/issues/288), so instead I've added some other specs that were available on the gfm repo
- `gfm-extra.txt` was removed as it was no longer needed
- Minor improvements to strikethrough / task lists to pass new specs

With this PR, there are 49 pending specs remaining, primarily focused around table / autolink / footnote support.