### PR TITLE
 add a newline before and after tartrazine code block is consider mor…

### DIFF
--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -283,7 +283,7 @@ module Markd
       if lang
         lexer = Tartrazine.lexer(lang)
 
-        literal(formatter.format(node.text.chomp, lexer))
+        literal(formatter.format("\n#{node.text.chomp}\n", lexer))
       else
         code_tag_attrs = attrs(node)
         pre_tag_attrs = if @options.prettyprint?


### PR DESCRIPTION
This PR is for code review.

I add a new line both before and after the tartrazine code block, i consider use like this is more good look, check following screenshot.

![image](https://github.com/user-attachments/assets/00dee836-7bcd-4fa8-8c83-ffc2b8aa95ef)


I use it on my branch several days, i consider it is better,  it also makes it very easy for me to add the `copy` button in the upper right corner.

```css
button.copyBtn {
  float: right;
}
```

do you consider merge this?
