### PR TITLE
Add abstract methods for all node visitors

### DIFF
--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -49,6 +49,25 @@ module Markd
       false
     end
 
+    abstract def heading(node : Node, entering : Bool) : Nil
+    abstract def list(node : Node, entering : Bool) : Nil
+    abstract def item(node : Node, entering : Bool) : Nil
+    abstract def block_quote(node : Node, entering : Bool) : Nil
+    abstract def thematic_break(node : Node, entering : Bool) : Nil
+    abstract def code_block(node : Node, entering : Bool, formatter : T?) : Nil forall T
+    abstract def code(node : Node, entering : Bool) : Nil
+    abstract def html_block(node : Node, entering : Bool) : Nil
+    abstract def html_inline(node : Node, entering : Bool) : Nil
+    abstract def paragraph(node : Node, entering : Bool) : Nil
+    abstract def emphasis(node : Node, entering : Bool) : Nil
+    abstract def soft_break(node : Node, entering : Bool) : Nil
+    abstract def line_break(node : Node, entering : Bool) : Nil
+    abstract def strong(node : Node, entering : Bool) : Nil
+    abstract def strikethrough(node : Node, entering : Bool) : Nil
+    abstract def link(node : Node, entering : Bool) : Nil
+    abstract def image(node : Node, entering : Bool) : Nil
+    abstract def text(node : Node, entering : Bool) : Nil
+
     def render(document : Node, formatter : T?) forall T
       Utils.timer("rendering", @options.time) do
         walker = document.walker

--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -67,6 +67,9 @@ module Markd
     abstract def link(node : Node, entering : Bool) : Nil
     abstract def image(node : Node, entering : Bool) : Nil
     abstract def text(node : Node, entering : Bool) : Nil
+    abstract def table(node : Node, entering : Bool) : Nil
+    abstract def table_row(node : Node, entering : Bool) : Nil
+    abstract def table_cell(node : Node, entering : Bool) : Nil
 
     def render(document : Node, formatter : T?) forall T
       Utils.timer("rendering", @options.time) do

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -63,7 +63,7 @@ module Markd
       newline
     end
 
-    def table(node : Node, entering : Bool)
+    def table(node : Node, entering : Bool) : Nil
       has_body = node.data["has_body"]
       newline
       if entering
@@ -78,7 +78,7 @@ module Markd
       newline
     end
 
-    def table_row(node : Node, entering : Bool)
+    def table_row(node : Node, entering : Bool) : Nil
       newline
       is_heading = node.data["heading"]
       has_body = node.data["has_body"]
@@ -102,7 +102,7 @@ module Markd
       end
     end
 
-    def table_cell(node : Node, entering : Bool)
+    def table_cell(node : Node, entering : Bool) : Nil
       tag_name = node.data["heading"] ? "th" : "td"
       if !node.data["align"].to_s.empty?
         attrs = {"align" => node.data["align"]}
@@ -118,7 +118,7 @@ module Markd
       end
     end
 
-    def list(node : Node, entering : Bool)
+    def list(node : Node, entering : Bool) : Nil
       tag_name = node.data["type"] == "ordered" ? "ol" : "ul"
 
       newline

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -9,7 +9,7 @@ module Markd
 
     HEADINGS = %w(h1 h2 h3 h4 h5 h6)
 
-    def heading(node : Node, entering : Bool)
+    def heading(node : Node, entering : Bool) : Nil
       tag_name = HEADINGS[node.data["level"].as(Int32) - 1]
       if entering
         newline
@@ -21,7 +21,7 @@ module Markd
       end
     end
 
-    def code(node : Node, entering : Bool)
+    def code(node : Node, entering : Bool) : Nil
       tag("code") do
         code_body(node)
       end
@@ -31,7 +31,7 @@ module Markd
       output(node.text)
     end
 
-    def code_block(node : Node, entering : Bool, formatter : T?) forall T
+    def code_block(node : Node, entering : Bool, formatter : T?) : Nil forall T
       {% if @top_level.has_constant?("Tartrazine") %}
         render_code_block_use_tartrazine(node, formatter)
       {% else %}
@@ -43,17 +43,17 @@ module Markd
       languages.try(&.first?).try(&.strip.presence)
     end
 
-    def code_block_body(node : Node, lang : String?)
+    def code_block_body(node : Node, lang : String?) : Nil
       output(node.text)
     end
 
-    def thematic_break(node : Node, entering : Bool)
+    def thematic_break(node : Node, entering : Bool) : Nil
       newline
       tag("hr", attrs(node), self_closing: true)
       newline
     end
 
-    def block_quote(node : Node, entering : Bool)
+    def block_quote(node : Node, entering : Bool) : Nil
       newline
       if entering
         tag("blockquote", attrs(node))
@@ -137,7 +137,7 @@ module Markd
       newline
     end
 
-    def item(node : Node, entering : Bool)
+    def item(node : Node, entering : Bool) : Nil
       if entering
         tag("li", attrs(node))
 
@@ -164,7 +164,7 @@ module Markd
       end
     end
 
-    def link(node : Node, entering : Bool)
+    def link(node : Node, entering : Bool) : Nil
       if entering
         attrs = attrs(node)
         destination = node.data["destination"].as(String)
@@ -196,7 +196,7 @@ module Markd
       base_url.resolve(uri).to_s
     end
 
-    def image(node : Node, entering : Bool)
+    def image(node : Node, entering : Bool) : Nil
       if entering
         if @disable_tag == 0
           destination = node.data["destination"].as(String)
@@ -219,19 +219,19 @@ module Markd
       end
     end
 
-    def html_block(node : Node, entering : Bool)
+    def html_block(node : Node, entering : Bool) : Nil
       newline
       content = @options.safe? ? "<!-- raw HTML omitted -->" : node.text
       literal(content)
       newline
     end
 
-    def html_inline(node : Node, entering : Bool)
+    def html_inline(node : Node, entering : Bool) : Nil
       content = @options.safe? ? "<!-- raw HTML omitted -->" : node.text
       literal(content)
     end
 
-    def paragraph(node : Node, entering : Bool)
+    def paragraph(node : Node, entering : Bool) : Nil
       if (grand_parent = node.parent?.try &.parent?) && grand_parent.type.list?
         return if grand_parent.data["tight"]
       end
@@ -245,7 +245,7 @@ module Markd
       end
     end
 
-    def emphasis(node : Node, entering : Bool)
+    def emphasis(node : Node, entering : Bool) : Nil
       if entering
         node.data["strong_stack"] = @strong_stack
         @strong_stack = 0
@@ -258,16 +258,16 @@ module Markd
       end
     end
 
-    def soft_break(node : Node, entering : Bool)
+    def soft_break(node : Node, entering : Bool) : Nil
       literal("\n")
     end
 
-    def line_break(node : Node, entering : Bool)
+    def line_break(node : Node, entering : Bool) : Nil
       tag("br", self_closing: true)
       newline
     end
 
-    def strong(node : Node, entering : Bool)
+    def strong(node : Node, entering : Bool) : Nil
       @strong_stack -= 1 if @options.gfm && !entering
 
       tag("strong", end_tag: !entering) if (@strong_stack == 0)
@@ -275,11 +275,11 @@ module Markd
       @strong_stack += 1 if @options.gfm && entering
     end
 
-    def strikethrough(node : Node, entering : Bool)
+    def strikethrough(node : Node, entering : Bool) : Nil
       tag("del", end_tag: !entering)
     end
 
-    def text(node : Node, entering : Bool)
+    def text(node : Node, entering : Bool) : Nil
       output(node.text)
     end
 


### PR DESCRIPTION
This PR:

* Adds abstract methods for all node visitors in the `Renderer` class
* Sets explicit `Nil` returns in all node visitor methods

Fixes #56 

It *may* be a breaking change for someone implementing renderers? Not sure. 