### PR TITLE
Table support

### DIFF
--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -426,7 +426,7 @@ Here's a link to [Freedom Planet 2][].
 
 ### Sequential cells
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a | b | c |
 | --- | --- | --- |
 | d || e |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -223,7 +223,7 @@ The header and delimiter row must match.
 But any of the body rows can be shorter. Rows longer
 than the header are truncated.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a | b | c |
 | --- | --- | ---
 | x

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -262,7 +262,7 @@ than the header are truncated.
 
 Tables with embedded pipes could be tricky.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b |
 | --- | --- |
 | Escaped pipes are \|okay\|. | Like \| this. |
@@ -375,7 +375,7 @@ This shouldn't assert.
 
 ### Embedded HTML
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a |
 | --- |
 | <strong>hello</strong> |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -302,7 +302,7 @@ Tables with embedded pipes could be tricky.
 
 This shouldn't assert.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a |
 --- |
 .

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -474,7 +474,7 @@ Here's a link to [Freedom Planet 2][].
 
 ### a table can be recognised when separated from a paragraph of text without an empty line
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 123
 456
 | a | b |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -400,7 +400,7 @@ This shouldn't assert.
 
 ### Reference-style links
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 Here's a link to [Freedom Planet 2][].
 
 | Here's a link to [Freedom Planet 2][] in a table header. |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -262,7 +262,7 @@ than the header are truncated.
 
 Tables with embedded pipes could be tricky.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a | b |
 | --- | --- |
 | Escaped pipes are \|okay\|. | Like \| this. |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -74,7 +74,7 @@ Hi!
 
 Here we demonstrate some edge cases about what is and isn't a table.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | Not enough table | to be considered table |
 
 | Not enough table | to be considered table |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -451,7 +451,7 @@ Here's a link to [Freedom Planet 2][].
 
 ### Interaction with emphasis
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a | b |
 | --- | --- |
 |***(a)***|

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -210,7 +210,7 @@ fff | ggg | hhh | iii | jjj
 
 The header and delimiter row must match.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a | b | c |
 | --- | --- |
 | this | isn't | okay |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -10,7 +10,7 @@ license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
 
 Here's a well-formed table, doing everything it should.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | abc | def |
 | --- | --- |
 | ghi | jkl |
@@ -210,7 +210,7 @@ fff | ggg | hhh | iii | jjj
 
 The header and delimiter row must match.
 
-```````````````````````````````` example
+```````````````````````````````` example pending
 | a | b | c |
 | --- | --- |
 | this | isn't | okay |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -179,7 +179,7 @@ Hi!
 
 Table alignment:
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 aaa | bbb | ccc | ddd | eee
 :-- | --- | :-: | --- | --:
 fff | ggg | hhh | iii | jjj

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -40,7 +40,7 @@ We're going to mix up the table now; we'll demonstrate that inline formatting
 works fine, but block elements don't.  You can also have empty cells, and the
 textual alignment of the columns is shown to be irrelevant.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 Hello!
 
 | _abc_ | セン |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -121,7 +121,7 @@ Here we demonstrate some edge cases about what is and isn't a table.
 
 A "simpler" table, GFM style:
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 abc | def
 --- | ---
 xyz | ghi

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -145,7 +145,7 @@ xyz | ghi
 We are making the parser slighly more lax here. Here is a table with spaces at
 the end:
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 Hello!
 
 | _abc_ | セン |

--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -3454,7 +3454,7 @@ bar
 The header row must match the [delimiter row] in the number of cells.  If not,
 a table will not be recognized:
 
-```````````````````````````````` example table
+```````````````````````````````` example table pending
 | abc | def |
 | --- |
 | bar |

--- a/src/markd/node.cr
+++ b/src/markd/node.cr
@@ -49,6 +49,7 @@ module Markd
       Type::CustomBlock,
       Type::Table,
       Type::TableRow,
+      Type::TableCell,
     }
 
     alias DataValue = String | Int32 | Bool

--- a/src/markd/node.cr
+++ b/src/markd/node.cr
@@ -25,6 +25,8 @@ module Markd
       CustomInLine
       CustomBlock
       Table
+      TableCell
+      TableRow
 
       def container?
         CONTAINER_TYPES.includes?(self)
@@ -46,6 +48,7 @@ module Markd
       Type::CustomInLine,
       Type::CustomBlock,
       Type::Table,
+      Type::TableRow,
     }
 
     alias DataValue = String | Int32 | Bool

--- a/src/markd/node.cr
+++ b/src/markd/node.cr
@@ -24,6 +24,7 @@ module Markd
 
       CustomInLine
       CustomBlock
+      Table
 
       def container?
         CONTAINER_TYPES.includes?(self)
@@ -44,6 +45,7 @@ module Markd
       Type::BlockQuote,
       Type::CustomInLine,
       Type::CustomBlock,
+      Type::Table,
     }
 
     alias DataValue = String | Int32 | Bool

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -16,6 +16,7 @@ module Markd::Parser
       Node::Type::List          => Rule::List.new,
       Node::Type::Item          => Rule::Item.new,
       Node::Type::Paragraph     => Rule::Paragraph.new,
+      Node::Type::Table         => Rule::Table.new,
     }
 
     property! tip : Node?

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -123,7 +123,7 @@ module Markd::Parser
         # this is a little performance optimization
         unless @indented
           first_char = @line[@next_nonspace]?
-          unless first_char && (Rule::MAYBE_SPECIAL.includes?(first_char) || first_char.ascii_number?)
+          unless first_char && (Rule::MAYBE_SPECIAL.includes?(first_char) || first_char.ascii_number? || @line.match(/(?<!\\)\|/))
             advance_next_nonspace
             break
           end

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -197,7 +197,7 @@ module Markd::Parser
       @inline_lexer.refmap = @refmap
       while (event = walker.next)
         node, entering = event
-        if !entering && (node.type.paragraph? || node.type.heading? || node.type.table?)
+        if !entering && (node.type.paragraph? || node.type.heading? || node.type.table_cell?)
           @inline_lexer.parse(node)
         end
       end

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -123,7 +123,7 @@ module Markd::Parser
         # this is a little performance optimization
         unless @indented
           first_char = @line[@next_nonspace]?
-          unless first_char && (Rule::MAYBE_SPECIAL.includes?(first_char) || first_char.ascii_number? || @line.match(/(?<!\\)\|/))
+          unless first_char && (Rule::MAYBE_SPECIAL.includes?(first_char) || first_char.ascii_number? || @line.match(Rule::TABLE_CELL_SEPARATOR))
             advance_next_nonspace
             break
           end

--- a/src/markd/parsers/block.cr
+++ b/src/markd/parsers/block.cr
@@ -197,7 +197,7 @@ module Markd::Parser
       @inline_lexer.refmap = @refmap
       while (event = walker.next)
         node, entering = event
-        if !entering && (node.type.paragraph? || node.type.heading?)
+        if !entering && (node.type.paragraph? || node.type.heading? || node.type.table?)
           @inline_lexer.parse(node)
         end
       end

--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -90,6 +90,8 @@ module Markd
             link(node, entering)
           when Node::Type::Image
             image(node, entering)
+          when Node::Type::Table
+            table(node, entering)
           else
             text(node, entering)
           end

--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -92,6 +92,10 @@ module Markd
             image(node, entering)
           when Node::Type::Table
             table(node, entering)
+          when Node::Type::TableRow
+            table_row(node, entering)
+          when Node::Type::TableCell
+            table_cell(node, entering)
           else
             text(node, entering)
           end

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -68,6 +68,8 @@ module Markd
       if entering
         tag("table", attrs(node))
       else
+        tag("tbody", end_tag: true)
+        newline
         tag("table", end_tag: true)
       end
       newline
@@ -75,24 +77,32 @@ module Markd
 
     def table_row(node : Node, entering : Bool)
       newline
-      is_heading= node.data["heading"] ? "th" : "td"
+      is_heading = node.data["heading"]
       if entering
-        tag("thead") if is_heading
+        if is_heading
+          tag("thead")
+          newline
+        end
         tag("tr", attrs(node))
       else
         tag("tr", end_tag: true)
-        tag("thead, end_tag: true") if is_heading
+        newline
+        if is_heading
+          tag("thead", end_tag: true)
+          newline
+          tag("tbody")
+          newline
+        end
       end
-      newline
     end
-
 
     def table_cell(node : Node, entering : Bool)
       newline
+      tag_name = node.data["heading"] ? "th" : "td"
       if entering
-        tag("td", attrs(node))
+        tag(tag_name, attrs(node))
         output(node.text)
-        tag("td", end_tag: true)
+        tag(tag_name, end_tag: true)
       end
       newline
     end

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -73,6 +73,27 @@ module Markd
       newline
     end
 
+    def table_row(node : Node, entering : Bool)
+      newline
+      if entering
+        tag("tr", attrs(node))
+      else
+        tag("tr", end_tag: true)
+      end
+      newline
+    end
+
+
+    def table_cell(node : Node, entering : Bool)
+      newline
+      if entering
+        tag("td", attrs(node))
+        output(node.text)
+        tag("td", end_tag: true)
+      end
+      newline
+    end
+
     def list(node : Node, entering : Bool)
       tag_name = node.data["type"] == "ordered" ? "ol" : "ul"
 

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -63,6 +63,16 @@ module Markd
       newline
     end
 
+    def table(node : Node, entering : Bool)
+      newline
+      if entering
+        tag("table", attrs(node))
+      else
+        tag("table", end_tag: true)
+      end
+      newline
+    end
+
     def list(node : Node, entering : Bool)
       tag_name = node.data["type"] == "ordered" ? "ol" : "ul"
 

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -104,9 +104,14 @@ module Markd
 
     def table_cell(node : Node, entering : Bool)
       tag_name = node.data["heading"] ? "th" : "td"
+      if !node.data["align"].to_s.empty?
+        attrs = {"align" => node.data["align"]}
+      else
+        attrs = {} of String => String
+      end
       if entering
         newline
-        tag(tag_name, attrs(node))
+        tag(tag_name, attrs)
       else
         tag(tag_name, end_tag: true)
         newline

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -97,14 +97,14 @@ module Markd
     end
 
     def table_cell(node : Node, entering : Bool)
-      newline
       tag_name = node.data["heading"] ? "th" : "td"
       if entering
+        newline
         tag(tag_name, attrs(node))
-        output(node.text)
+      else
         tag(tag_name, end_tag: true)
+        newline
       end
-      newline
     end
 
     def list(node : Node, entering : Bool)

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -75,10 +75,13 @@ module Markd
 
     def table_row(node : Node, entering : Bool)
       newline
+      is_heading= node.data["heading"] ? "th" : "td"
       if entering
+        tag("thead") if is_heading
         tag("tr", attrs(node))
       else
         tag("tr", end_tag: true)
+        tag("thead, end_tag: true") if is_heading
       end
       newline
     end

--- a/src/markd/renderers/html_renderer.cr
+++ b/src/markd/renderers/html_renderer.cr
@@ -64,12 +64,15 @@ module Markd
     end
 
     def table(node : Node, entering : Bool)
+      has_body = node.data["has_body"]
       newline
       if entering
         tag("table", attrs(node))
       else
-        tag("tbody", end_tag: true)
-        newline
+        if has_body
+          tag("tbody", end_tag: true)
+          newline
+        end
         tag("table", end_tag: true)
       end
       newline
@@ -78,6 +81,7 @@ module Markd
     def table_row(node : Node, entering : Bool)
       newline
       is_heading = node.data["heading"]
+      has_body = node.data["has_body"]
       if entering
         if is_heading
           tag("thead")
@@ -90,8 +94,10 @@ module Markd
         if is_heading
           tag("thead", end_tag: true)
           newline
-          tag("tbody")
-          newline
+          if has_body
+            tag("tbody")
+            newline
+          end
         end
       end
     end

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -77,6 +77,10 @@ module Markd
 
     GFM_DISALLOWED_HTML_TAGS = %w[title textarea style xmp iframe noembed noframes script plaintext]
 
+    TABLE_HEADING_SEPARATOR = /^(\|?\s*:{0,1}-:{0,1}+\s*)+(\||\s*)$/
+    TABLE_CELL_SEPARATOR = /(?<!\\)\|/
+
+
     # Match Value
     #
     # - None: no match

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -78,8 +78,7 @@ module Markd
     GFM_DISALLOWED_HTML_TAGS = %w[title textarea style xmp iframe noembed noframes script plaintext]
 
     TABLE_HEADING_SEPARATOR = /^(\|?\s*:{0,1}-:{0,1}+\s*)+(\||\s*)$/
-    TABLE_CELL_SEPARATOR = /(?<!\\)\|/
-
+    TABLE_CELL_SEPARATOR    = /(?<!\\)\|/
 
     # Match Value
     #

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -14,7 +14,7 @@ module Markd
     ATTRIBUTE_VALUE_SPEC_STRING = "(?:" + "\\s*=" + "\\s*" + ATTRIBUTE_VALUE_STRING + ")"
     ATTRIBUTE                   = "(?:" + "\\s+" + ATTRIBUTE_NAME_STRING + ATTRIBUTE_VALUE_SPEC_STRING + "?)"
 
-    MAYBE_SPECIAL  = {'#', '`', '~', '*', '+', '_', '=', '<', '>', '-'}
+    MAYBE_SPECIAL  = {'#', '`', '~', '*', '+', '_', '=', '<', '>', '-', '|'}
     THEMATIC_BREAK = /^(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})[ \t]*$/
 
     ESCAPABLE = /^#{ESCAPABLE_STRING}/

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -68,6 +68,7 @@ module Markd::Rule
         row.data["heading"] = i == 0
         row.data["has_body"] = has_body
         container.append_child(row)
+        # This splits on | but not on \| (escaped |)
         cells = line.rstrip.rstrip("|").split(/(?<!\\)\|/)[...max_row_size]
         while cells.size < max_row_size
           cells << ""

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -52,8 +52,6 @@ module Markd::Rule
         # We need to convert it into a paragraph
         # I am fairly sure this is not supposed to work
         container.type = Node::Type::Paragraph
-        # Patch the text to have the leading |s
-        container.text = container.text
         return
       end
 

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -5,8 +5,7 @@ module Markd::Rule
     SEPARATOR_REGEX = /^(\|?\s*-+\s*)+(\||\s*)$/
 
     def match(parser : Parser, container : Node) : MatchValue
-      if match?(parser)  # Looks like the 1st line of a table
-        seek(parser)
+      if match?(parser) # Looks like the 1st line of a table
         parser.close_unmatched_blocks
         parser.add_child(Node::Type::Table, 0)
 
@@ -18,8 +17,7 @@ module Markd::Rule
 
     def continue(parser : Parser, container : Node) : ContinueStatus
       # Only continue if line looks like a divider or a table row
-      if match_continuation?(parser)   
-        seek(parser)
+      if match_continuation?(parser)
         ContinueStatus::Continue
       else
         ContinueStatus::Stop
@@ -31,9 +29,9 @@ module Markd::Rule
       # So, let's parse it and shove it into the tree
 
       original_text = container.text.rstrip.split("\n").map do |l|
-        "|#{l}"
+        "#{l}"
       end.join("\n")
-      lines = container.text.strip.split('\n')
+      lines = container.text.strip.split("\n")
 
       # Make all lines end with '|' for convenience
       lines = lines.map do |l|
@@ -44,16 +42,18 @@ module Markd::Rule
         end
       end
 
-      row_sizes = lines[...2].map(&.count "|").uniq!
+      row_sizes = lines[...2].map do |l|
+        l.strip.strip("|").split(/(?<!\\)\|/).size
+      end.uniq!
 
       # Do we have a real table?
       # * At least two lines
       # * Second line is a divider
       # * First two lines have the same number of cells
 
-      if lines.size < 2 || !"|#{lines[1]}".match(SEPARATOR_REGEX) ||
+      if lines.size < 2 || !lines[1].match(SEPARATOR_REGEX) ||
          row_sizes.size != 1
-        # Not enough table or a broken table. 
+        # Not enough table or a broken table.
         # We need to convert it into a paragraph
         # I am fairly sure this is not supposed to work
         container.type = Node::Type::Paragraph
@@ -74,7 +74,7 @@ module Markd::Rule
         row.data["has_body"] = has_body
         container.append_child(row)
         # This splits on | but not on \| (escaped |)
-        cells = line.rstrip.rstrip("|").split(/(?<!\\)\|/)[...max_row_size]
+        cells = line.strip.strip("|").split(/(?<!\\)\|/)[...max_row_size]
 
         # Each row should have exactly the same size as the header.
         while cells.size < max_row_size
@@ -100,15 +100,13 @@ module Markd::Rule
     end
 
     private def match?(parser)
-      !parser.indented && parser.line[0]? == '|' && parser.line.size > 2
+      !parser.indented && \
+         (parser.line[0]? == '|' || parser.line.match(/(?<!\\)\|/)) &&
+          parser.line.size > 2
     end
 
     private def match_continuation?(parser : Parser)
       !parser.indented && (parser.line[0]? == '|' || parser.line.match(SEPARATOR_REGEX) || parser.line.match(/(?<!\\)\|/))
-    end
-
-    private def seek(parser : Parser)
-      parser.advance_offset(1, false)
     end
   end
 end

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -28,6 +28,23 @@ module Markd::Rule
       # So, let's parse it and shove them into the tree
 
       lines = container.text.strip.split('\n')
+
+      # Do we have a real table?
+      # FIXME: do a real regex for divider
+      if lines.size < 2 || !"|#{lines[1]}".match(/---/)
+        # Not enough table. We need to convert it into a paragraph
+        text = lines.map do |line|
+          "|#{line}"
+        end.join("\n")
+        # Create a paragraph with this text and replace the table node with it
+        paragraph = Node.new(Node::Type::Paragraph)
+        paragraph.text = text
+        container.insert_after(paragraph)
+        container.unlink
+        parser.tip = paragraph
+        return
+      end
+
       lines.each_with_index do |line, i|
         next if i == 1
         row = Node.new(Node::Type::TableRow)

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -38,7 +38,6 @@ module Markd::Rule
           cell.text = text.strip
           cell.data["heading"] = i == 0
           row.append_child(cell)
-          pp! row.last_child.text
         end
       end
     end

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -25,7 +25,20 @@ module Markd::Rule
 
     def token(parser : Parser, container : Node) : Nil
       # The table contents are in container.text (except the leading | in each line)
-      # So, let's parse it and shove it into container.data
+      # So, let's parse it and shove them into the tree
+
+      lines = container.text.split('\n')
+      lines.each do |line| 
+        row = Node.new(Node::Type::TableRow)
+        container.append_child(row)
+        line.rstrip("|").split('|').each do |text|
+          pp! text
+          cell = Node.new(Node::Type::TableCell)
+          cell.text = text.strip
+          row.append_child(cell)
+          pp! row.last_child.text
+        end
+      end
     end
 
     def can_contain?(type : Node::Type) : Bool

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -2,7 +2,6 @@ module Markd::Rule
   struct Table
     include Rule
 
-    SEPARATOR_REGEX = /^(\|?\s*:{0,1}-:{0,1}+\s*)+(\||\s*)$/
 
     def match(parser : Parser, container : Node) : MatchValue
       if match?(parser) # Looks like the 1st line of a table
@@ -34,7 +33,7 @@ module Markd::Rule
       lines = container.text.strip.split("\n")
 
       row_sizes = lines[...2].map do |l|
-        l.strip.strip("|").split(/(?<!\\)\|/).size
+        l.strip.strip("|").split(TABLE_CELL_SEPARATOR).size
       end.uniq!
 
       # Do we have a real table?
@@ -42,7 +41,7 @@ module Markd::Rule
       # * Second line is a divider
       # * First two lines have the same number of cells
 
-      if lines.size < 2 || !lines[1].match(SEPARATOR_REGEX) ||
+      if lines.size < 2 || !lines[1].match(TABLE_HEADING_SEPARATOR) ||
          row_sizes.size != 1
         # Not enough table or a broken table.
         # We need to convert it into a paragraph
@@ -77,7 +76,7 @@ module Markd::Rule
         row.data["has_body"] = has_body
         container.append_child(row)
         # This splits on | but not on \| (escaped |)
-        cells = line.strip.strip("|").split(/(?<!\\)\|/)[...max_row_size]
+        cells = line.strip.strip("|").split(TABLE_CELL_SEPARATOR)[...max_row_size]
 
         # Each row should have exactly the same size as the header.
         while cells.size < max_row_size
@@ -105,12 +104,12 @@ module Markd::Rule
 
     private def match?(parser)
       !parser.indented && \
-         (parser.line[0]? == '|' || parser.line.match(/(?<!\\)\|/)) &&
+         (parser.line[0]? == '|' || parser.line.match(TABLE_CELL_SEPARATOR)) &&
           parser.line.size > 2
     end
 
     private def match_continuation?(parser : Parser)
-      !parser.indented && (parser.line[0]? == '|' || parser.line.match(SEPARATOR_REGEX) || parser.line.match(/(?<!\\)\|/))
+      !parser.indented && (parser.line[0]? == '|' || parser.line.match(TABLE_HEADING_SEPARATOR) || parser.line.match(TABLE_CELL_SEPARATOR))
     end
   end
 end

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -97,7 +97,7 @@ module Markd::Rule
     end
 
     private def match_continuation?(parser : Parser)
-      !parser.indented && (parser.line[0]? == '|' || parser.line.match(SEPARATOR_REGEX))
+      !parser.indented && (parser.line[0]? == '|' || parser.line.match(SEPARATOR_REGEX) || parser.line.match(/(?<!\\)\|/))
     end
 
     private def seek(parser : Parser)

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -60,11 +60,12 @@ module Markd::Rule
       container.data["has_body"] = has_body
 
       alignments = strip_pipe(lines[1].strip).split(TABLE_CELL_SEPARATOR).map do |cell|
-        if cell.strip.starts_with?(":") && cell.strip.ends_with?(":")
+        cell = cell.strip
+        if cell.starts_with?(":") && cell.ends_with?(":")
           "center"
-        elsif cell.strip.starts_with?(":")
+        elsif cell.starts_with?(":")
           "left"
-        elsif cell.strip.ends_with?(":")
+        elsif cell.ends_with?(":")
           "right"
         else
           ""

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -17,7 +17,6 @@ module Markd::Rule
     end
 
     def continue(parser : Parser, container : Node) : ContinueStatus
-      pp! parser.line
       if match_continuation?(parser)
         seek(parser)
         ContinueStatus::Continue

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -55,7 +55,7 @@ module Markd::Rule
       has_body = lines.size > 2
       container.data["has_body"] = has_body
 
-      alignments = lines[1].strip.strip("|").split(/(?<!\\)\|/).map do |cell|
+      alignments = lines[1].strip.strip("|").split(TABLE_CELL_SEPARATOR).map do |cell|
         if cell.strip.starts_with?(":") && cell.strip.ends_with?(":")
           "center"
         elsif cell.strip.starts_with?(":")

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -6,7 +6,7 @@ module Markd::Rule
       if match?(parser)
         seek(parser)
         parser.close_unmatched_blocks
-        parser.add_child(Node::Type::Table, parser.next_nonspace)
+        node = parser.add_child(Node::Type::Table, parser.next_nonspace)
 
         MatchValue::Container
       else
@@ -24,15 +24,16 @@ module Markd::Rule
     end
 
     def token(parser : Parser, container : Node) : Nil
-      # do nothing
+      # The table contents are in container.text (except the leading | in each line)
+      # So, let's parse it and shove it into container.data
     end
 
     def can_contain?(type : Node::Type) : Bool
-      !type.item?
+      !type.container?
     end
 
     def accepts_lines? : Bool
-      false
+      true
     end
 
     private def match?(parser)

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -47,9 +47,8 @@ module Markd::Rule
       # * At least two lines
       # * Second line is a divider
       # * First two lines have the same number of cells
-      # FIXME: do a real regex for divider
 
-      if lines.size < 2 || !"|#{lines[1]}".match(/-/) ||
+      if lines.size < 2 || !"|#{lines[1]}".match(/^(\|\s*-+\s*)+(\||\s*)$/) ||
          row_sizes.size != 1
         # Not enough table. We need to convert it into a paragraph
         # Turn the table into a paragraph. I am fairly sure this is not supposed to work

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -69,7 +69,7 @@ module Markd::Rule
         row.data["heading"] = i == 0
         row.data["has_body"] = has_body
         container.append_child(row)
-        cells = line.rstrip.rstrip("|").split('|')[...max_row_size]
+        cells = line.rstrip.rstrip("|").split(/(?<!\\)\|/)[...max_row_size]
         while cells.size < max_row_size
           cells << ""
         end

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -27,14 +27,16 @@ module Markd::Rule
       # The table contents are in container.text (except the leading | in each line)
       # So, let's parse it and shove them into the tree
 
-      lines = container.text.split('\n')
+      lines = container.text.strip.split('\n')
       lines.each_with_index do |line, i|
+        next if i == 1
         row = Node.new(Node::Type::TableRow)
         row.data["heading"] = i == 0
         container.append_child(row)
         line.rstrip("|").split('|').each do |text|
           cell = Node.new(Node::Type::TableCell)
           cell.text = text.strip
+          cell.data["heading"] = i == 0
           row.append_child(cell)
           pp! row.last_child.text
         end

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -35,10 +35,10 @@ module Markd::Rule
       # Do we have a real table?
       # * At least two lines
       # * Second line is a divider
-      # * All lines have the same number of cells 
+      # * All lines have the same number of cells
       # FIXME: do a real regex for divider
       if lines.size < 2 || !"|#{lines[1]}".match(/-/) ||
-        lines.map(&.count "|").uniq.size != 1
+         lines.map(&.count "|").uniq!.size != 1
         # Not enough table. We need to convert it into a paragraph
         # Turn the table into a paragraph. I am fairly sure this is not supposed to work
         container.type = Node::Type::Paragraph
@@ -48,7 +48,7 @@ module Markd::Rule
       end
 
       # Do we have row cell count mismatches?
-      lines.map(&.count "|").uniq.size
+      lines.map(&.count "|").uniq!.size
 
       has_body = lines.size > 2
       container.data["has_body"] = has_body

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -93,7 +93,7 @@ module Markd::Rule
     end
 
     private def match?(parser)
-      !parser.indented && parser.line[0]? == '|'
+      !parser.indented && parser.line[0]? == '|' && parser.line.size > 2
     end
 
     private def match_continuation?(parser : Parser)

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -2,6 +2,8 @@ module Markd::Rule
   struct Table
     include Rule
 
+    SEPARATOR_REGEX = /^(\|?\s*-+\s*)+(\||\s*)$/
+
     def match(parser : Parser, container : Node) : MatchValue
       if match?(parser)
         seek(parser)
@@ -15,7 +17,8 @@ module Markd::Rule
     end
 
     def continue(parser : Parser, container : Node) : ContinueStatus
-      if match?(parser)
+      pp! parser.line
+      if match_continuation?(parser)
         seek(parser)
         ContinueStatus::Continue
       else
@@ -48,7 +51,7 @@ module Markd::Rule
       # * Second line is a divider
       # * First two lines have the same number of cells
 
-      if lines.size < 2 || !"|#{lines[1]}".match(/^(\|\s*-+\s*)+(\||\s*)$/) ||
+      if lines.size < 2 || !"|#{lines[1]}".match(SEPARATOR_REGEX) ||
          row_sizes.size != 1
         # Not enough table. We need to convert it into a paragraph
         # Turn the table into a paragraph. I am fairly sure this is not supposed to work
@@ -92,6 +95,10 @@ module Markd::Rule
 
     private def match?(parser)
       !parser.indented && parser.line[0]? == '|'
+    end
+
+    private def match_continuation?(parser : Parser)
+      !parser.indented && (parser.line[0]? == '|' || parser.line.match(SEPARATOR_REGEX))
     end
 
     private def seek(parser : Parser)

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -28,11 +28,11 @@ module Markd::Rule
       # So, let's parse it and shove them into the tree
 
       lines = container.text.split('\n')
-      lines.each do |line| 
+      lines.each_with_index do |line, i|
         row = Node.new(Node::Type::TableRow)
+        row.data["heading"] = i == 0
         container.append_child(row)
         line.rstrip("|").split('|').each do |text|
-          pp! text
           cell = Node.new(Node::Type::TableCell)
           cell.text = text.strip
           row.append_child(cell)

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -2,9 +2,9 @@ module Markd::Rule
   struct Table
     include Rule
 
-
     def match(parser : Parser, container : Node) : MatchValue
-      if match?(parser) # Looks like the 1st line of a table
+      # Looks like the 1st line of a table and we have gfm enabled
+      if match?(parser) && parser.gfm
         parser.close_unmatched_blocks
         parser.add_child(Node::Type::Table, 0)
 

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -52,7 +52,7 @@ module Markd::Rule
         row.data["heading"] = i == 0
         row.data["has_body"] = has_body
         container.append_child(row)
-        line.rstrip("|").split('|').each do |text|
+        line.rstrip.rstrip("|").split('|').each do |text|
           cell = Node.new(Node::Type::TableCell)
           cell.text = text.strip
           cell.data["heading"] = i == 0

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -24,12 +24,13 @@ module Markd::Rule
     end
 
     def token(parser : Parser, container : Node) : Nil
-      # The table contents are in container.text (except the leading | in each line)
+      # The table contents are in container.text
       # So, let's parse it and shove it into the tree
 
-      original_text = container.text.rstrip.split("\n").join("\n")
       lines = container.text.strip.split("\n")
 
+      # FIXME: there is a corner case where a row ends with "\|"
+      # which is probably going to be counted wrong.
       row_sizes = lines[...2].map do |l|
         l.strip.strip("|").split(TABLE_CELL_SEPARATOR).size
       end.uniq!
@@ -46,7 +47,7 @@ module Markd::Rule
         # I am fairly sure this is not supposed to work
         container.type = Node::Type::Paragraph
         # Patch the text to have the leading |s
-        container.text = original_text
+        container.text = container.text
         return
       end
 

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -30,7 +30,8 @@ module Markd::Rule
       lines = container.text.strip.split("\n")
 
       # FIXME: there is a corner case where a row ends with "\|"
-      # which is probably going to be counted wrong.
+      # which is probably going to be counted wrong. Same for other rstrip("|")
+      # in this function
       row_sizes = lines[...2].map do |l|
         l.strip.strip("|").split(TABLE_CELL_SEPARATOR).size
       end.uniq!

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -33,8 +33,12 @@ module Markd::Rule
       lines = container.text.strip.split('\n')
 
       # Do we have a real table?
+      # * At least two lines
+      # * Second line is a divider
+      # * All lines have the same number of cells 
       # FIXME: do a real regex for divider
-      if lines.size < 2 || !"|#{lines[1]}".match(/-/)
+      if lines.size < 2 || !"|#{lines[1]}".match(/-/) ||
+        lines.map(&.count "|").uniq.size != 1
         # Not enough table. We need to convert it into a paragraph
         # Turn the table into a paragraph. I am fairly sure this is not supposed to work
         container.type = Node::Type::Paragraph
@@ -42,6 +46,9 @@ module Markd::Rule
         container.text = original_text
         return
       end
+
+      # Do we have row cell count mismatches?
+      lines.map(&.count "|").uniq.size
 
       has_body = lines.size > 2
       container.data["has_body"] = has_body

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -1,0 +1,51 @@
+module Markd::Rule
+  struct Table
+    include Rule
+
+    def match(parser : Parser, container : Node) : MatchValue
+      if match?(parser)
+        seek(parser)
+        parser.close_unmatched_blocks
+        parser.add_child(Node::Type::Table, parser.next_nonspace)
+
+        MatchValue::Container
+      else
+        MatchValue::None
+      end
+    end
+
+    def continue(parser : Parser, container : Node) : ContinueStatus
+      if match?(parser)
+        seek(parser)
+        ContinueStatus::Continue
+      else
+        ContinueStatus::Stop
+      end
+    end
+
+    def token(parser : Parser, container : Node) : Nil
+      # do nothing
+    end
+
+    def can_contain?(type : Node::Type) : Bool
+      !type.item?
+    end
+
+    def accepts_lines? : Bool
+      false
+    end
+
+    private def match?(parser)
+      !parser.indented && parser.line[parser.next_nonspace]? == '|'
+    end
+
+    private def seek(parser : Parser)
+      parser.advance_next_nonspace
+      parser.advance_offset(1, false)
+
+      if space_or_tab?(parser.line[parser.offset]?)
+        parser.advance_offset(1, true)
+      end
+    end
+  end
+end

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -27,9 +27,7 @@ module Markd::Rule
       # The table contents are in container.text (except the leading | in each line)
       # So, let's parse it and shove it into the tree
 
-      original_text = container.text.rstrip.split("\n").map do |l|
-        "#{l}"
-      end.join("\n")
+      original_text = container.text.rstrip.split("\n").join("\n")
       lines = container.text.strip.split("\n")
 
       row_sizes = lines[...2].map do |l|


### PR DESCRIPTION
Working implementation.

There seems to be a bug in markd about escaping characters inside `<code>` which prevents the "Escaped pipes" test from passing but it's unrelated to table support.

It passes the tests in the gfm suite related to tables except those that rely on a working escaping support.

~~There is *one* regression test failing, need to look into it.~~

I consider this finished :-)