### PR TITLE
Build ameba linter on pr to fix permission issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,56 @@ on:
       - master
 
 jobs:
+  code_format:
+    runs-on: ubuntu-latest
+    name: Code Format check
+    steps:
+      - name: Install latest Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Check out repository code
+        uses: actions/checkout@master
+      - name: Install dependencies
+        run: shards install --without-development
+      - name: Check format
+        run: |
+          if ! crystal tool format --check; then
+            crystal tool format
+            git diff
+            exit 1
+          fi
+  ameba_linter:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ameba-version: [v1.6.4]
+    name: Ameba ${{ matrix.ameba-version }} linter check
+    steps:
+      - name: Install latest Crystal
+        uses: crystal-lang/install-crystal@v1
+      - name: Check out repository code
+        uses: actions/checkout@master
+      - name: Install dependencies
+        run: shards install --without-development
+      - name: Cache Ameba binary
+        id: cache-ameba
+        uses: actions/cache@v3
+        with:
+          path: bin/ameba
+          key: ${{ runner.os }}-ameba-${{ matrix.ameba-version }}
+
+      - name: Build Ameba
+        if: steps.cache-ameba.outputs.cache-hit != 'true'
+        run: |
+          git clone --branch ${{ matrix.ameba-version }} --single-branch https://github.com/crystal-ameba/ameba.git
+          cd ameba
+          make bin/ameba CRFLAGS='-Dpreview_mt --release --no-debug'
+          mkdir -p ../bin
+          mv bin/ameba ../bin/ameba
+          cd ..
+          rm -rf ameba
+
+      - name: Run Ameba Linter
+        run: bin/ameba -c .ameba.yml
   specs:
     strategy:
       fail-fast: false
@@ -35,18 +85,3 @@ jobs:
 
     - name: Run specs
       run: crystal spec --error-on-warnings --error-trace
-
-    - name: Run formatting checks
-      if: matrix.os != 'windows-latest'
-      run: |
-        if ! crystal tool format --check; then
-          crystal tool format
-          git diff
-          exit 1
-        fi
-    
-    - name: Run Crystal Ameba Linter
-      if: matrix.os == 'ubuntu-latest'
-      uses: crystal-ameba/github-action@v0.12.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Running ameba linter requires using the repo owner's token. If it's a pull request submission, it cannot correctly obtain the corresponding permissions and should be prohibited from running to avoid CI failing.