### PR TITLE
Fix pipe escaping in table cells

### DIFF
--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -262,7 +262,7 @@ than the header are truncated.
 
 Tables with embedded pipes could be tricky.
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a | b |
 | --- | --- |
 | Escaped pipes are \|okay\|. | Like \| this. |
@@ -317,7 +317,7 @@ This shouldn't assert.
 
 ### Escaping
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 | a | b |
 | --- | --- |
 | \\ | `\\` |

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -90,7 +90,8 @@ module Markd::Rule
         # Create cells with text and metadata
         cells.each_with_index do |text, j|
           cell = Node.new(Node::Type::TableCell)
-          cell.text = text.strip
+          # Cell text should be stripped and escaped pipes unescaped
+          cell.text = text.strip.gsub("\\|", "|")
           cell.data["align"] = alignments[j]
           cell.data["heading"] = i == 0
           row.append_child(cell)


### PR DESCRIPTION
Fixes a bug in the table implementation, makes two more gfw extension test pass. Fixes #75