### PR TITLE
Do not use question mark in `Utils.timer`'s parameter

### DIFF
--- a/src/markd/utils.cr
+++ b/src/markd/utils.cr
@@ -2,8 +2,8 @@ require "json"
 
 module Markd
   module Utils
-    def self.timer(label : String, measure_time? : Bool, &)
-      return yield unless measure_time?
+    def self.timer(label : String, measure_time : Bool, &)
+      return yield unless measure_time
 
       start_time = Time.utc
       yield


### PR DESCRIPTION
This is now warned by crystal-lang/crystal#12197.