### PR TITLE
Implement part of the autolinks spec

### DIFF
--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -9218,7 +9218,7 @@ www.commonmark.org
 
 After a [valid domain], zero or more non-space non-`<` characters may follow:
 
-```````````````````````````````` example autolink pending
+```````````````````````````````` example autolink
 Visit www.commonmark.org/help for more information.
 .
 <p>Visit <a href="http://www.commonmark.org/help">www.commonmark.org/help</a> for more information.</p>

--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -9230,7 +9230,7 @@ Trailing punctuation (specifically, `?`, `!`, `.`, `,`, `:`, `*`, `_`, and `~`)
 will not be considered part of the autolink, though they may be included in the
 interior of the link:
 
-```````````````````````````````` example autolink pending
+```````````````````````````````` example autolink
 Visit www.commonmark.org.
 
 Visit www.commonmark.org/a.b.

--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -9285,7 +9285,7 @@ www.google.com/search?q=commonmark&hl;
 
 `<` immediately ends an autolink.
 
-```````````````````````````````` example autolink pending
+```````````````````````````````` example autolink
 www.commonmark.org/he<lp
 .
 <p><a href="http://www.commonmark.org/he">www.commonmark.org/he</a>&lt;lp</p>

--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -9263,7 +9263,7 @@ This check is only done when the link ends in a closing parentheses `)`, so if
 the only parentheses are in the interior of the autolink, no special rules are
 applied:
 
-```````````````````````````````` example autolink pending
+```````````````````````````````` example autolink
 www.google.com/search?q=(business))+ok
 .
 <p><a href="http://www.google.com/search?q=(business))+ok">www.google.com/search?q=(business))+ok</a></p>

--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -9210,7 +9210,7 @@ and no underscores may be present in the last two segments of the domain.
 
 The scheme `http` will be inserted automatically:
 
-```````````````````````````````` example autolink pending
+```````````````````````````````` example autolink
 www.commonmark.org
 .
 <p><a href="http://www.commonmark.org">www.commonmark.org</a></p>

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -30,7 +30,6 @@ module Markd::Parser
 
     private def process_line(node : Node)
       char = char_at?(@pos)
-
       return false unless char && char != Char::ZERO
 
       res = case char
@@ -846,7 +845,7 @@ module Markd::Parser
 
     private def main_char?(char)
       case char
-      when '\n', '`', '[', ']', '\\', '!', '<', '&', '*', '_', '\'', '"', ':'
+      when '\n', '`', '[', ']', '\\', '!', '<', '&', '*', '_', '\'', '"', ':', 'w'
         false
       when '~'
         !@options.gfm

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -58,6 +58,8 @@ module Markd::Parser
               close_bracket(node)
             when '<'
               auto_link(node) || html_tag(node)
+            when 'w'
+              auto_link(node)
             when '&'
               entity(node)
             when ':'
@@ -433,6 +435,9 @@ module Markd::Parser
       elsif text = match(Rule::AUTO_LINK)
         node.append_child(link(text, false))
         return true
+      elsif text = match(Rule::WWW_AUTO_LINK)
+        node.append_child(link(text, false, true))
+        return true
       end
 
       false
@@ -550,9 +555,12 @@ module Markd::Parser
       end
     end
 
-    private def link(match : String, email = false) : Node
-      dest = match[1..-2]
+    private def link(match : String, email = false, add_proto = false) : Node
+      dest = match.lstrip("<").rstrip(">")
       destination = email ? "mailto:#{dest}" : dest
+      if add_proto
+        destination = "http://#{destination}"
+      end
 
       node = Node.new(Node::Type::Link)
       node.data["title"] = ""

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -64,6 +64,7 @@ module Markd
 
     EMAIL_AUTO_LINK = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
     AUTO_LINK       = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
+    WWW_AUTO_LINK   = /^www\.[a-zA-Z0-9\.]+/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/
     WHITESPACE      = /[ \t\n\x0b\x0c\x0d]+/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -64,7 +64,7 @@ module Markd
 
     EMAIL_AUTO_LINK = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
     AUTO_LINK       = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
-    WWW_AUTO_LINK   = /^www\.[a-zA-Z0-9\.]+/
+    WWW_AUTO_LINK   = /^www(\.[a-zA-Z0-9\-]{1,})+(\/[^\s<]*)?/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/
     WHITESPACE      = /[ \t\n\x0b\x0c\x0d]+/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -64,7 +64,7 @@ module Markd
 
     EMAIL_AUTO_LINK = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
     AUTO_LINK       = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
-    WWW_AUTO_LINK   = /^www(\.[a-zA-Z0-9\-]{1,})+(\/[^\s<]*)?/
+    WWW_AUTO_LINK   = /^www(\.[a-zA-Z0-9\-]{1,})+(\/[^\s<]*[^\s<.,])?/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/
     WHITESPACE      = /[ \t\n\x0b\x0c\x0d]+/


### PR DESCRIPTION
This PR adds support for autolinks starting with www and passes several tests in the GFM spec

Further work needed of course

Part of #82 I think?

Specifically: `match_main?` has a speed optimization and breaks nodes on specific characters. Since the spec requires detecting email addresses, and those can start with any letter match_main? would have to break the node on every letter, which makes no sense.

So, it may need to be turned into some massively complicated regex (sorry!) that breaks on the same chars it breaks now, but also in `www http:// https:// ftp:// and foo@`