### PR TITLE
Fix failing table test (Fixes #87)

### DIFF
--- a/spec/fixtures/gfm-spec.txt
+++ b/spec/fixtures/gfm-spec.txt
@@ -3422,7 +3422,7 @@ block-level structure:
 </blockquote>
 ````````````````````````````````
 
-```````````````````````````````` example table pending
+```````````````````````````````` example table
 | abc | def |
 | --- | --- |
 | bar | baz |

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -124,12 +124,10 @@ module Markd::Rule
     private def match_continuation?(parser : Parser)
       !parser.indented && (parser.line[0]? == '|' ||
         parser.line.match(TABLE_HEADING_SEPARATOR) ||
-        parser.line.match(TABLE_CELL_SEPARATOR)) || !( # Lines that are not empty and are not the start of a
-      # block-level structure are ALSO continuations (see gfm-spec.txt:3397)
-
-parser.line.strip.empty? ||
-        parser.line.matches? /^(?:>|\#{1,6}|`{3}|\t{1}|\s{4}|(?:[*-+]\s)+|[0-9]+\.)+/
-        )
+        parser.line.match(TABLE_CELL_SEPARATOR)) ||
+        # Lines that are not empty and are not the start of a
+        # block-level structure are ALSO continuations (see gfm-spec.txt:3397)
+        !(parser.line.strip.empty? || parser.line.matches?(/^(?:>|\#{1,6}|`{3}|\t{1}|\s{4}|(?:[*-+]\s)+|[0-9]+\.)+/))
     end
 
     private def strip_pipe(text : String) : String

--- a/src/markd/rules/table.cr
+++ b/src/markd/rules/table.cr
@@ -124,7 +124,12 @@ module Markd::Rule
     private def match_continuation?(parser : Parser)
       !parser.indented && (parser.line[0]? == '|' ||
         parser.line.match(TABLE_HEADING_SEPARATOR) ||
-        parser.line.match(TABLE_CELL_SEPARATOR))
+        parser.line.match(TABLE_CELL_SEPARATOR)) || !( # Lines that are not empty and are not the start of a
+      # block-level structure are ALSO continuations (see gfm-spec.txt:3397)
+
+parser.line.strip.empty? ||
+        parser.line.matches? /^(?:>|\#{1,6}|`{3}|\t{1}|\s{4}|(?:[*-+]\s)+|[0-9]+\.)+/
+        )
     end
 
     private def strip_pipe(text : String) : String


### PR DESCRIPTION
Lines after a table that are not empty and are not the beginning of a block-level structure are table rows, which feels totally bogus but it's the spec.