### PR TITLE
More autolinks fixed

### DIFF
--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -637,10 +637,10 @@ http://🍄.ga/ http://x🍄.ga/
 <p><a href="http://%F0%9F%8D%84.ga/">http://🍄.ga/</a> <a href="http://x%F0%9F%8D%84.ga/">http://x🍄.ga/</a></p>
 ````````````````````````````````
 
-```````````````````````````````` example pending
+```````````````````````````````` example
 This shouldn't crash everything: (_A_@_.A
 .
-<IGNORE>
+<p>This shouldn't crash everything: (<em>A</em>@_.A</p>
 ````````````````````````````````
 
 ```````````````````````````````` example
@@ -800,7 +800,7 @@ Hello[^"><script>alert(1)</script>]
 
 Autolink and strikethrough.
 
-```````````````````````````````` example pending
+```````````````````````````````` example autolink
 ~~www.google.com~~
 
 ~~http://google.com~~
@@ -811,7 +811,7 @@ Autolink and strikethrough.
 
 Autolink and tables.
 
-```````````````````````````````` example pending
+```````````````````````````````` example autolink
 | a | b |
 | --- | --- |
 | https://github.com www.github.com | http://pokemon.com |

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -538,7 +538,7 @@ size (100) for parsing delimiters in inlines.c
 
 ## Autolinks
 
-```````````````````````````````` example autolink
+```````````````````````````````` example autolink pending
 : http://google.com https://google.com
 
 <http://google.com/å> http://google.com/å

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -538,7 +538,7 @@ size (100) for parsing delimiters in inlines.c
 
 ## Autolinks
 
-```````````````````````````````` example autolink pending
+```````````````````````````````` example autolink
 : http://google.com https://google.com
 
 <http://google.com/å> http://google.com/å

--- a/spec/fixtures/gfm-extensions.txt
+++ b/spec/fixtures/gfm-extensions.txt
@@ -538,7 +538,7 @@ size (100) for parsing delimiters in inlines.c
 
 ## Autolinks
 
-```````````````````````````````` example pending
+```````````````````````````````` example autolink
 : http://google.com https://google.com
 
 <http://google.com/å> http://google.com/å

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -967,6 +967,7 @@ module Markd::Parser
     # These cleanups are defined in the spec
 
     private def autolink_cleanup(text : String) : String
+      return text if text.empty?
       # When an autolink ends in `)`, we scan the entire autolink for the total number
       # of parentheses.  If there is a greater number of closing parentheses than
       # opening ones, we don't consider the unmatched trailing parentheses part of the

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -95,6 +95,13 @@ module Markd::Parser
               else
                 false
               end
+            when 'm'
+              # Catch mailto: autolinks for GFM
+              if @options.gfm && @options.autolink && (@pos == 0 || char_at?(@pos - 1) != '<')
+                auto_link(node)
+              else
+                false
+              end
             when '&'
               entity(node)
             when ':'
@@ -495,6 +502,12 @@ module Markd::Parser
         node.append_child(text(post)) if post.size > 0 && matched_text != clean_text
         return true
       elsif @options.gfm && (matched_text = match(Rule::XMPP_AUTO_LINK))
+        clean_text = autolink_cleanup(matched_text)
+        _, post = @text.split(clean_text, 2)
+        node.append_child(link(clean_text, false, false))
+        node.append_child(text(post)) if post.size > 0 && matched_text != clean_text
+        return true
+      elsif @options.gfm && (matched_text = match(Rule::MAILTO_AUTO_LINK))
         clean_text = autolink_cleanup(matched_text)
         _, post = @text.split(clean_text, 2)
         node.append_child(link(clean_text, false, false))

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -938,6 +938,7 @@ module Markd::Parser
           return 0
         end
 
+        matched_text = text.match(Rule::PROTOCOL_AUTO_LINK).to_s
         m = autolink_cleanup(text.match(Rule::PROTOCOL_AUTO_LINK).to_s)
         m.size
       elsif text.includes?("@") && text.matches?(Rule::EXTENDED_EMAIL_AUTO_LINK)

--- a/src/markd/parsers/inline.cr
+++ b/src/markd/parsers/inline.cr
@@ -472,9 +472,12 @@ module Markd::Parser
         return true
       elsif @options.gfm && (matched_text = match(Rule::PROTOCOL_AUTO_LINK))
         clean_text = autolink_cleanup(matched_text)
-        link = link(clean_text, false, false)
-        node.append_child(link)
-        node.append_child(text(matched_text[clean_text.size..])) if clean_text != matched_text
+
+        # The matched text may not be at the beginning of the string
+        # it happens for the case `'http://google.com'`
+        _, post = @text.split(clean_text, 2)
+        node.append_child(link(clean_text, false, false))
+        node.append_child(text(post)) if post.size > 0 && matched_text != clean_text
         return true
       elsif @options.gfm && (matched_text = match(Rule::EXTENDED_EMAIL_AUTO_LINK))
         # Emails that end in - or _ are declared not to be links by the spec:
@@ -994,7 +997,7 @@ module Markd::Parser
       # Trailing punctuation (specifically, `?`, `!`, `.`, `,`, `:`, `*`, `_`, and `~`)
       # will not be considered part of the autolink, though they may be included in the
       # interior of the link
-      while "?!.,:*~_".includes?(text[-1])
+      while "\"'?!.,:*~_".includes?(text[-1])
         text = text[0..-2]
       end
 

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -70,18 +70,23 @@ module Markd
     # underscores may be present in the last two segments of the domain.
     #
     # Alphanumeric characters in this context include emojis.
-    NEXT_TO_LAST_DOMAIN_SEGMENT = /(?:[a-zA-Z0-9\-\p{Emoji_Presentation}\-]+\.)/
     LAST_DOMAIN_SEGMENT = /(?:[a-zA-Z0-9\-\p{Emoji_Presentation}\-]+)/
-    OTHER_DOMAIN_SEGMENTS = /(?:[a-zA-Z0-9\p{Emoji_Presentation}\-_]+\.)/
-    DOMAIN_NAME = /#{OTHER_DOMAIN_SEGMENTS}*#{NEXT_TO_LAST_DOMAIN_SEGMENT}*#{LAST_DOMAIN_SEGMENT}/
+    OTHER_DOMAIN_SEGMENTS = /(?:[a-zA-Z0-9\p{Emoji_Presentation}\-_]+)/
+    # The spec wants to capture greedily, even invalid domain names and then
+    # reject the invalid ones later.
+    # For example: www.xxx.yyy._zzz is never linked because of the 
+    # _ in the last segment.
+    DOMAIN_NAME = /(?:#{OTHER_DOMAIN_SEGMENTS}\.)*#{OTHER_DOMAIN_SEGMENTS}/
+    VALID_DOMAIN_NAME = /(?:#{OTHER_DOMAIN_SEGMENTS}\.)*(?:#{LAST_DOMAIN_SEGMENT}\.)*#{LAST_DOMAIN_SEGMENT}/
+    VALID_URL_PATH = /(?:\/[^\s<]*)?/
 
     AUTOLINK_PROTOCOLS = /^((?:http|https|ftp):\/\/)|xmpp:/
 
     EMAIL_AUTO_LINK          = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
     EXTENDED_EMAIL_AUTO_LINK = /^([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)[-_]*/
     AUTO_LINK                = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
-    WWW_AUTO_LINK            = /^www(\.[a-zA-Z0-9\-]{1,})+(\/[^\s<]*[^\s<?!.,:*_~])?/
-    PROTOCOL_AUTO_LINK = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}+(?<!_)\.[a-zA-Z0-9-]+(?<!_)\/?[^\s<]*[^\s?!.,:*_~]/
+    WWW_AUTO_LINK            = /^www\.#{VALID_DOMAIN_NAME}#{VALID_URL_PATH}/
+    PROTOCOL_AUTO_LINK = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}#{VALID_URL_PATH}[^\s?!.,:*_~]/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/
     WHITESPACE      = /[ \t\n\x0b\x0c\x0d]+/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -67,7 +67,7 @@ module Markd
     EXTENDED_EMAIL_AUTO_LINK = /^([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)[-_]*/
     AUTO_LINK                = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
     WWW_AUTO_LINK            = /^www(\.[a-zA-Z0-9\-]{1,})+(\/[^\s<]*[^\s<?!.,:*_~])?/
-    PROTOCOL_AUTO_LINK       = /^(?:http|https|ftp):\/\/([a-zA-Z0-9\-_.]{2,})+(\/[^\s<]*[^\s?!.,:*_~])?/
+    PROTOCOL_AUTO_LINK       = /^(?:http|https|ftp):\/\/([a-zA-Z0-9\-_.\p{Emoji_Presentation}]{2,})+(\/[^\s<]*[^\s?!.,:*_~])?/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/
     WHITESPACE      = /[ \t\n\x0b\x0c\x0d]+/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -63,11 +63,25 @@ module Markd
 
     LINK_DESTINATION_BRACES = Regex.new("^(?:[<](?:[^<>\\t\\n\\\\\\x00]|" + ESCAPED_CHAR_STRING + ")*[>])")
 
+    # A valid domain name is:
+    #
+    # segments of alphanumeric characters, underscores (_) and hyphens (-) 
+    # separated by periods (.). There must be at least one period, and no 
+    # underscores may be present in the last two segments of the domain.
+    #
+    # Alphanumeric characters in this context include emojis.
+    NEXT_TO_LAST_DOMAIN_SEGMENT = /(?:[a-zA-Z0-9\-\p{Emoji_Presentation}\-]+\.)/
+    LAST_DOMAIN_SEGMENT = /(?:[a-zA-Z0-9\-\p{Emoji_Presentation}\-]+)/
+    OTHER_DOMAIN_SEGMENTS = /(?:[a-zA-Z0-9\p{Emoji_Presentation}\-_]+\.)/
+    DOMAIN_NAME = /#{OTHER_DOMAIN_SEGMENTS}*#{NEXT_TO_LAST_DOMAIN_SEGMENT}*#{LAST_DOMAIN_SEGMENT}/
+
+    AUTOLINK_PROTOCOLS = /^((?:http|https|ftp):\/\/)|xmpp:/
+
     EMAIL_AUTO_LINK          = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
     EXTENDED_EMAIL_AUTO_LINK = /^([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)[-_]*/
     AUTO_LINK                = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
     WWW_AUTO_LINK            = /^www(\.[a-zA-Z0-9\-]{1,})+(\/[^\s<]*[^\s<?!.,:*_~])?/
-    PROTOCOL_AUTO_LINK       = /^(?:http|https|ftp):\/\/([a-zA-Z0-9\-_.\p{Emoji_Presentation}]{2,})+(\/[^\s<]*[^\s?!.,:*_~])?/
+    PROTOCOL_AUTO_LINK = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}+(?<!_)\.[a-zA-Z0-9-]+(?<!_)\/?[^\s<]*[^\s?!.,:*_~]/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/
     WHITESPACE      = /[ \t\n\x0b\x0c\x0d]+/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -87,7 +87,7 @@ module Markd
     AUTO_LINK                = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
     WWW_AUTO_LINK            = /^www\.#{DOMAIN_NAME}#{VALID_URL_PATH}/
     XMPP_AUTO_LINK           = /^xmpp:[A-Za-z0-9]+@#{DOMAIN_NAME}#{VALID_URL_PATH}/
-    MAILTO_AUTO_LINK           = /^mailto:[A-Za-z0-9]+@#{DOMAIN_NAME}/
+    MAILTO_AUTO_LINK         = /^mailto:[A-Za-z0-9]+@#{DOMAIN_NAME}/
     PROTOCOL_AUTO_LINK       = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}#{VALID_URL_PATH}[^\s?!.,:*_~]/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -65,28 +65,29 @@ module Markd
 
     # A valid domain name is:
     #
-    # segments of alphanumeric characters, underscores (_) and hyphens (-) 
-    # separated by periods (.). There must be at least one period, and no 
+    # segments of alphanumeric characters, underscores (_) and hyphens (-)
+    # separated by periods (.). There must be at least one period, and no
     # underscores may be present in the last two segments of the domain.
     #
     # Alphanumeric characters in this context include emojis.
-    LAST_DOMAIN_SEGMENT = /(?:[a-zA-Z0-9\-\p{Emoji_Presentation}\-]+)/
+    LAST_DOMAIN_SEGMENT   = /(?:[a-zA-Z0-9\-\p{Emoji_Presentation}\-]+)/
     OTHER_DOMAIN_SEGMENTS = /(?:[a-zA-Z0-9\p{Emoji_Presentation}\-_]+)/
     # The spec wants to capture greedily, even invalid domain names and then
     # reject the invalid ones later.
-    # For example: www.xxx._yyy.zzz is never linked because of the 
+    # For example: www.xxx._yyy.zzz is never linked because of the
     # _ in the last segment.
-    DOMAIN_NAME = /(?:#{OTHER_DOMAIN_SEGMENTS}\.)*#{OTHER_DOMAIN_SEGMENTS}/
+    DOMAIN_NAME       = /(?:#{OTHER_DOMAIN_SEGMENTS}\.)*#{OTHER_DOMAIN_SEGMENTS}/
     VALID_DOMAIN_NAME = /^(?:#{OTHER_DOMAIN_SEGMENTS}\.)*(?:#{LAST_DOMAIN_SEGMENT}\.)+#{LAST_DOMAIN_SEGMENT}$/
-    VALID_URL_PATH = /(?:\/[^\s<]*)?/
+    VALID_URL_PATH    = /(?:\/[^\s<]*)?/
 
-    AUTOLINK_PROTOCOLS = /^((?:http|https|ftp):\/\/)|xmpp:/
+    AUTOLINK_PROTOCOLS = /^(?:http|https|ftp):\/\//
 
     EMAIL_AUTO_LINK          = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
     EXTENDED_EMAIL_AUTO_LINK = /^([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)[-_]*/
     AUTO_LINK                = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
     WWW_AUTO_LINK            = /^www\.#{DOMAIN_NAME}#{VALID_URL_PATH}/
-    PROTOCOL_AUTO_LINK = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}#{VALID_URL_PATH}[^\s?!.,:*_~]/
+    XMPP_AUTO_LINK           = /^xmpp:[A-Za-z0-9]+@#{DOMAIN_NAME}#{VALID_URL_PATH}/
+    PROTOCOL_AUTO_LINK       = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}#{VALID_URL_PATH}[^\s?!.,:*_~]/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/
     WHITESPACE      = /[ \t\n\x0b\x0c\x0d]+/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -74,10 +74,10 @@ module Markd
     OTHER_DOMAIN_SEGMENTS = /(?:[a-zA-Z0-9\p{Emoji_Presentation}\-_]+)/
     # The spec wants to capture greedily, even invalid domain names and then
     # reject the invalid ones later.
-    # For example: www.xxx.yyy._zzz is never linked because of the 
+    # For example: www.xxx._yyy.zzz is never linked because of the 
     # _ in the last segment.
     DOMAIN_NAME = /(?:#{OTHER_DOMAIN_SEGMENTS}\.)*#{OTHER_DOMAIN_SEGMENTS}/
-    VALID_DOMAIN_NAME = /(?:#{OTHER_DOMAIN_SEGMENTS}\.)*(?:#{LAST_DOMAIN_SEGMENT}\.)*#{LAST_DOMAIN_SEGMENT}/
+    VALID_DOMAIN_NAME = /^(?:#{OTHER_DOMAIN_SEGMENTS}\.)*(?:#{LAST_DOMAIN_SEGMENT}\.)+#{LAST_DOMAIN_SEGMENT}$/
     VALID_URL_PATH = /(?:\/[^\s<]*)?/
 
     AUTOLINK_PROTOCOLS = /^((?:http|https|ftp):\/\/)|xmpp:/
@@ -85,7 +85,7 @@ module Markd
     EMAIL_AUTO_LINK          = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
     EXTENDED_EMAIL_AUTO_LINK = /^([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)[-_]*/
     AUTO_LINK                = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
-    WWW_AUTO_LINK            = /^www\.#{VALID_DOMAIN_NAME}#{VALID_URL_PATH}/
+    WWW_AUTO_LINK            = /^www\.#{DOMAIN_NAME}#{VALID_URL_PATH}/
     PROTOCOL_AUTO_LINK = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}#{VALID_URL_PATH}[^\s?!.,:*_~]/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/

--- a/src/markd/rule.cr
+++ b/src/markd/rule.cr
@@ -83,10 +83,11 @@ module Markd
     AUTOLINK_PROTOCOLS = /^(?:http|https|ftp):\/\//
 
     EMAIL_AUTO_LINK          = /^<([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)>/
-    EXTENDED_EMAIL_AUTO_LINK = /^([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)[-_]*/
+    EXTENDED_EMAIL_AUTO_LINK = /^([a-zA-Z0-9][a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+)[-_]*/
     AUTO_LINK                = /^<[A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\x00-\x20]*>/i
     WWW_AUTO_LINK            = /^www\.#{DOMAIN_NAME}#{VALID_URL_PATH}/
     XMPP_AUTO_LINK           = /^xmpp:[A-Za-z0-9]+@#{DOMAIN_NAME}#{VALID_URL_PATH}/
+    MAILTO_AUTO_LINK           = /^mailto:[A-Za-z0-9]+@#{DOMAIN_NAME}/
     PROTOCOL_AUTO_LINK       = /#{AUTOLINK_PROTOCOLS}#{DOMAIN_NAME}#{VALID_URL_PATH}[^\s?!.,:*_~]/
 
     WHITESPACE_CHAR = /^[ \t\n\x0b\x0c\x0d]/


### PR DESCRIPTION
This PR makes most of the tests in `spec/fixtures/gfm-extensions.txt:542` pass (see below) and also enables a few more cases which pass if the autolinks extension is enabled.

There are 2 cases that are failing:

First, which I can probably fix but I am just tired:

`mmmmailto:scyther@pokemon.com` 

Should be: `"<p>mmmmailto:<a href=\"mailto:scyther@pokemon.com\">scyther@pokemon.com</a></p>\n"`

Is: `"<p>mmm<a href=\"mailto:scyther@pokemon.com\">mailto:scyther@pokemon.com</a></p>\n"`

Second, which is just wrong because that is not a valid domain (domains MUST contain a dot according to the same spec):

`**Autolink and http://inlines**`

Should be:  `"<p><strong>Autolink and <a href=\"http://inlines\">http://inlines</a></strong></p>\n"`

Is: `"<p><strong>Autolink and http://inlines</strong></p>\n"`


