### PR TITLE
Add default value for `formatter` arg in `Renderer#render`

### DIFF
--- a/src/markd/renderer.cr
+++ b/src/markd/renderer.cr
@@ -72,7 +72,7 @@ module Markd
     abstract def table_row(node : Node, entering : Bool) : Nil
     abstract def table_cell(node : Node, entering : Bool) : Nil
 
-    def render(document : Node, formatter : T?) forall T
+    def render(document : Node, formatter : T? = nil) forall T
       Utils.timer("rendering", @options.time?) do
         walker = document.walker
         while (event = walker.next)


### PR DESCRIPTION
The `formatter` argument was added in https://github.com/icyleaf/markd/pull/67 but it's optional.

Adding a default value maintains API compatibility with v0.5.0.